### PR TITLE
Fix wasLastUpdatedBefore to be in days, not hours

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,7 +92,7 @@ function isLabeledStale(issue: Issue, label: string): boolean {
 }
 
 function wasLastUpdatedBefore(issue: Issue, num_days: number): boolean {
-  const daysInMillis = 1000 * 60 * 60 * num_days;
+  const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
   const millisSinceLastUpdated =
     new Date().getTime() - new Date(issue.updated_at).getTime();
   return millisSinceLastUpdated >= daysInMillis;


### PR DESCRIPTION
The parameters and variables names make it seem like this is the intended behavior.