### PR TITLE
Fix closing tag in only-labels description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
   exempt-pr-label:
     description: 'The label to apply when a pull request is exempt from being marked stale.'
   only-labels:
-    description: 'Only issues or pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled)' and can be a comma-separated list of labels.'
+    description: 'Only issues or pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled) and can be a comma-separated list of labels.'
     default: ''
   operations-per-run:
     description: 'The maximum number of operations per run, used to control rate limiting.'

--- a/action.yml
+++ b/action.yml
@@ -3,33 +3,33 @@ description: 'Close issues and pull requests with no recent activity'
 author: 'GitHub'
 inputs:
   repo-token:
-    description: 'Token for the repository. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
+    description: 'Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`.'
     required: true
   stale-issue-message:
     description: 'The message to post on the issue when tagging it. If none provided, will not mark issues stale.'
   stale-pr-message:
     description: 'The message to post on the pr when tagging it. If none provided, will not mark pull requests stale.'
   days-before-stale:
-    description: 'The number of days old an issue can be before marking it stale'
+    description: 'The number of days old an issue can be before marking it stale.'
     default: 60
   days-before-close:
     description: 'The number of days to wait to close an issue or pull request after it being marked stale. Set to -1 to never close stale issues.'
     default: 7
   stale-issue-label:
-    description: 'The label to apply when an issue is stale'
+    description: 'The label to apply when an issue is stale.'
     default: 'Stale'
   exempt-issue-label:
-    description: 'The label to apply when an issue is exempt from being marked stale'
+    description: 'The label to apply when an issue is exempt from being marked stale.'
   stale-pr-label:
-    description: 'The label to apply when a pull request is stale'
+    description: 'The label to apply when a pull request is stale.'
     default: 'Stale'
   exempt-pr-label:
-    description: 'The label to apply when a pull request is exempt from being marked stale'
+    description: 'The label to apply when a pull request is exempt from being marked stale.'
   only-labels:
-    description: 'Only issues or pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled)' and can be a comma-separated list of labels
+    description: 'Only issues or pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled)' and can be a comma-separated list of labels.'
     default: ''
   operations-per-run:
-    description: 'The maximum number of operations per run, used to control rate limiting'
+    description: 'The maximum number of operations per run, used to control rate limiting.'
     default: 30
 runs:
   using: 'node12'


### PR DESCRIPTION
The `only-labels` description was missing the closing tag `'`.