### PR TITLE
Remove stale labels and ignore stale issues with comments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Jest Tests",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/node_modules/jest/bin/jest",
+            "args": [
+                "-i"
+            ],
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "internalConsoleOptions": "openOnSessionStart",
+            "console": "integratedTerminal",
+            "outFiles": [
+                "${workspaceRoot}/build/dist/**/*"
+            ]
+        }
+    ]
+}

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -43,11 +43,17 @@ const DefaultProcessorOptions: IssueProcessorOptions = {
   exemptPrLabels: '',
   onlyLabels: '',
   operationsPerRun: 100,
-  debugOnly: true
+  debugOnly: true,
+  removeStaleWhenUpdated: false
 };
 
 test('empty issue list results in 1 operation', async () => {
-  const processor = new IssueProcessor(DefaultProcessorOptions, async () => []);
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async () => [],
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
+  );
 
   // process our fake issue list
   const operationsLeft = await processor.processIssues(1);
@@ -61,8 +67,11 @@ test('processing an issue with no label will make it stale', async () => {
     generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z')
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -77,8 +86,11 @@ test('processing a stale issue will close it', async () => {
     generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'])
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -93,8 +105,11 @@ test('processing a stale PR will close it', async () => {
     generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'])
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -109,8 +124,10 @@ test('closed issues will not be marked stale', async () => {
     generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, [], true)
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => []
   );
 
   // process our fake issue list
@@ -122,11 +139,21 @@ test('closed issues will not be marked stale', async () => {
 
 test('stale closed issues will not be closed', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'], true)
+    generateIssue(
+      1,
+      'My first issue',
+      '2020-01-01T17:00:00Z',
+      false,
+      ['Stale'],
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -141,8 +168,11 @@ test('closed prs will not be marked stale', async () => {
     generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, [], true)
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -154,11 +184,21 @@ test('closed prs will not be marked stale', async () => {
 
 test('stale closed prs will not be closed', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'], true)
+    generateIssue(
+      1,
+      'My first PR',
+      '2020-01-01T17:00:00Z',
+      true,
+      ['Stale'],
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -170,7 +210,15 @@ test('stale closed prs will not be closed', async () => {
 
 test('locked issues will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, [], false, true)
+    generateIssue(
+      1,
+      'My first issue',
+      '2020-01-01T17:00:00Z',
+      false,
+      [],
+      false,
+      true
+    )
   ];
 
   const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
@@ -186,11 +234,22 @@ test('locked issues will not be marked stale', async () => {
 
 test('stale locked issues will not be closed', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'], false, true)
+    generateIssue(
+      1,
+      'My first issue',
+      '2020-01-01T17:00:00Z',
+      false,
+      ['Stale'],
+      false,
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -202,7 +261,15 @@ test('stale locked issues will not be closed', async () => {
 
 test('locked prs will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, [], false, true)
+    generateIssue(
+      1,
+      'My first PR',
+      '2020-01-01T17:00:00Z',
+      true,
+      [],
+      false,
+      true
+    )
   ];
 
   const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
@@ -218,11 +285,22 @@ test('locked prs will not be marked stale', async () => {
 
 test('stale locked prs will not be closed', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'], false, true)
+    generateIssue(
+      1,
+      'My first PR',
+      '2020-01-01T17:00:00Z',
+      true,
+      ['Stale'],
+      false,
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -242,8 +320,11 @@ test('exempt issue labels will not be marked stale', async () => {
   let opts = DefaultProcessorOptions;
   opts.exemptIssueLabels = 'Exempt';
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -261,8 +342,11 @@ test('exempt issue labels will not be marked stale (multi issue label with space
   let opts = DefaultProcessorOptions;
   opts.exemptIssueLabels = 'Exempt, Cool, None';
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -280,8 +364,11 @@ test('exempt issue labels will not be marked stale (multi issue label)', async (
   let opts = DefaultProcessorOptions;
   opts.exemptIssueLabels = 'Exempt,Cool,None';
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -301,8 +388,11 @@ test('exempt pr labels will not be marked stale', async () => {
   let opts = DefaultProcessorOptions;
   opts.exemptIssueLabels = 'Cool';
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -323,8 +413,11 @@ test('stale issues should not be closed if days is set to -1', async () => {
   let opts = DefaultProcessorOptions;
   opts.daysBeforeClose = -1;
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -64,7 +64,7 @@ test('empty issue list results in 1 operation', async () => {
 
 test('processing an issue with no label will make it stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z')
+    generateIssue(1, 'An issue with no label', '2020-01-01T17:00:00Z')
   ];
 
   const processor = new IssueProcessor(
@@ -83,7 +83,13 @@ test('processing an issue with no label will make it stale', async () => {
 
 test('processing a stale issue will close it', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'])
+    generateIssue(
+      1,
+      'A stale issue that should be closed',
+      '2020-01-01T17:00:00Z',
+      false,
+      ['Stale']
+    )
   ];
 
   const processor = new IssueProcessor(
@@ -102,7 +108,13 @@ test('processing a stale issue will close it', async () => {
 
 test('processing a stale PR will close it', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'])
+    generateIssue(
+      1,
+      'A stale PR that should be closed',
+      '2020-01-01T17:00:00Z',
+      true,
+      ['Stale']
+    )
   ];
 
   const processor = new IssueProcessor(
@@ -121,7 +133,14 @@ test('processing a stale PR will close it', async () => {
 
 test('closed issues will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, [], true)
+    generateIssue(
+      1,
+      'A closed issue that will not be marked',
+      '2020-01-01T17:00:00Z',
+      false,
+      [],
+      true
+    )
   ];
 
   const processor = new IssueProcessor(
@@ -141,7 +160,7 @@ test('stale closed issues will not be closed', async () => {
   const TestIssueList: Issue[] = [
     generateIssue(
       1,
-      'My first issue',
+      'A stale closed issue',
       '2020-01-01T17:00:00Z',
       false,
       ['Stale'],
@@ -165,7 +184,14 @@ test('stale closed issues will not be closed', async () => {
 
 test('closed prs will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, [], true)
+    generateIssue(
+      1,
+      'A closed PR that will not be marked',
+      '2020-01-01T17:00:00Z',
+      true,
+      [],
+      true
+    )
   ];
 
   const processor = new IssueProcessor(
@@ -186,7 +212,7 @@ test('stale closed prs will not be closed', async () => {
   const TestIssueList: Issue[] = [
     generateIssue(
       1,
-      'My first PR',
+      'A stale closed PR that will not be closed again',
       '2020-01-01T17:00:00Z',
       true,
       ['Stale'],
@@ -212,7 +238,7 @@ test('locked issues will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
     generateIssue(
       1,
-      'My first issue',
+      'A locked issue that will not be stale',
       '2020-01-01T17:00:00Z',
       false,
       [],
@@ -236,7 +262,7 @@ test('stale locked issues will not be closed', async () => {
   const TestIssueList: Issue[] = [
     generateIssue(
       1,
-      'My first issue',
+      'A stale locked issue that will not be closed',
       '2020-01-01T17:00:00Z',
       false,
       ['Stale'],
@@ -263,7 +289,7 @@ test('locked prs will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
     generateIssue(
       1,
-      'My first PR',
+      'A locked PR that will not be marked stale',
       '2020-01-01T17:00:00Z',
       true,
       [],
@@ -287,7 +313,7 @@ test('stale locked prs will not be closed', async () => {
   const TestIssueList: Issue[] = [
     generateIssue(
       1,
-      'My first PR',
+      'A stale locked PR that will not be closed',
       '2020-01-01T17:00:00Z',
       true,
       ['Stale'],

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     default: 30
   remove-stale-when-updated:
     description: 'Remove stale labels from issues when they are updated or commented on.'
-    default: false
+    default: true
   debug-only:
     description: 'Run the processor in debug mode without actually performing any operations on live issues.'
     default: false

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   operations-per-run:
     description: 'The maximum number of operations per run, used to control rate limiting.'
     default: 30
+  remove-stale-when-updated:
+    description: 'Remove stale labels from issues when they are updated or commented on.'
+    default: false
   debug-only:
     description: 'Run the processor in debug mode without actually performing any operations on live issues.'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -8452,6 +8452,7 @@ class IssueProcessor {
         this.operationsLeft = 0;
         this.staleIssues = [];
         this.closedIssues = [];
+        this.removedLabelIssues = [];
         this.options = options;
         this.operationsLeft = options.operationsPerRun;
         this.client = new github.GitHub(options.repoToken);
@@ -8632,6 +8633,7 @@ class IssueProcessor {
     removeLabel(issue, label) {
         return __awaiter(this, void 0, void 0, function* () {
             core.debug(`Removing label ${label} from issue #${issue.number} - ${issue.title}`);
+            this.removedLabelIssues.push(issue);
             this.operationsLeft -= 1;
             if (this.options.debugOnly) {
                 return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8513,7 +8513,7 @@ class IssueProcessor {
                     core.debug(`Found a stale ${issueType}`);
                     yield this.processStaleIssue(issue, issueType, staleLabel);
                 }
-                else if (IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeStale)) {
+                else if (!IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeStale)) {
                     core.debug(`Marking ${issueType} stale because it was last updated on ${issue.updated_at}`);
                     yield this.markStale(issue, staleMessage, staleLabel);
                     this.operationsLeft -= 2;
@@ -8669,7 +8669,7 @@ class IssueProcessor {
     static updatedSince(timestamp, num_days) {
         const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
         const millisSinceLastUpdated = new Date().getTime() - new Date(timestamp).getTime();
-        return millisSinceLastUpdated >= daysInMillis;
+        return millisSinceLastUpdated < daysInMillis;
     }
     static parseCommaSeparatedString(s) {
         // String.prototype.split defaults to [''] when called on an empty string

--- a/dist/index.js
+++ b/dist/index.js
@@ -3756,7 +3756,7 @@ function getAndValidateArgs() {
         exemptPrLabels: core.getInput('exempt-pr-labels'),
         onlyLabels: core.getInput('only-labels'),
         operationsPerRun: parseInt(core.getInput('operations-per-run', { required: true })),
-        removeStaleWhenUpdated: core.getInput('remove-stale-when-updated') === 'true',
+        removeStaleWhenUpdated: !(core.getInput('remove-stale-when-updated') === 'false'),
         debugOnly: core.getInput('debug-only') === 'true'
     };
     for (const numberInput of [

--- a/dist/index.js
+++ b/dist/index.js
@@ -3756,6 +3756,7 @@ function getAndValidateArgs() {
         exemptPrLabels: core.getInput('exempt-pr-labels'),
         onlyLabels: core.getInput('only-labels'),
         operationsPerRun: parseInt(core.getInput('operations-per-run', { required: true })),
+        removeStaleWhenUpdated: core.getInput('remove-stale-when-updated') === 'true',
         debugOnly: core.getInput('debug-only') === 'true'
     };
     for (const numberInput of [
@@ -8447,7 +8448,7 @@ const github = __importStar(__webpack_require__(469));
  * Handle processing of issues for staleness/closure.
  */
 class IssueProcessor {
-    constructor(options, getIssues) {
+    constructor(options, getIssues, listIssueComments, getLabelCreationDate) {
         this.operationsLeft = 0;
         this.staleIssues = [];
         this.closedIssues = [];
@@ -8456,6 +8457,12 @@ class IssueProcessor {
         this.client = new github.GitHub(options.repoToken);
         if (getIssues) {
             this.getIssues = getIssues;
+        }
+        if (listIssueComments) {
+            this.listIssueComments = listIssueComments;
+        }
+        if (getLabelCreationDate) {
+            this.getLabelCreationDate = getLabelCreationDate;
         }
         if (this.options.debugOnly) {
             core.warning('Executing in debug mode. Debug output will be written but no issues will be processed.');
@@ -8490,23 +8497,23 @@ class IssueProcessor {
                     core.debug(`Skipping ${issueType} due to empty stale message`);
                     continue;
                 }
+                if (issue.state === 'closed') {
+                    core.debug(`Skipping ${issueType} because it is closed`);
+                    continue; // don't process closed issues
+                }
+                if (issue.locked) {
+                    core.debug(`Skipping ${issueType} because it is locked`);
+                    continue; // don't process locked issues
+                }
                 if (exemptLabels.some((exemptLabel) => IssueProcessor.isLabeled(issue, exemptLabel))) {
                     core.debug(`Skipping ${issueType} because it has an exempt label`);
                     continue; // don't process exempt issues
                 }
                 if (IssueProcessor.isLabeled(issue, staleLabel)) {
                     core.debug(`Found a stale ${issueType}`);
-                    if (this.options.daysBeforeClose >= 0 &&
-                        IssueProcessor.wasLastUpdatedBefore(issue, this.options.daysBeforeClose)) {
-                        core.debug(`Closing ${issueType} because it was last updated on ${issue.updated_at}`);
-                        yield this.closeIssue(issue);
-                        this.operationsLeft -= 1;
-                    }
-                    else {
-                        core.debug(`Ignoring stale ${issueType} because it was updated recenlty`);
-                    }
+                    yield this.processStaleIssue(issue, issueType, staleLabel);
                 }
-                else if (IssueProcessor.wasLastUpdatedBefore(issue, this.options.daysBeforeStale)) {
+                else if (IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeStale)) {
                     core.debug(`Marking ${issueType} stale because it was last updated on ${issue.updated_at}`);
                     yield this.markStale(issue, staleMessage, staleLabel);
                     this.operationsLeft -= 2;
@@ -8514,6 +8521,57 @@ class IssueProcessor {
             }
             // do the next batch
             return this.processIssues(page + 1);
+        });
+    }
+    // handle all of the stale issue logic when we find a stale issue
+    processStaleIssue(issue, issueType, staleLabel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (this.options.daysBeforeClose < 0) {
+                return; // nothing to do because we aren't closing stale issues
+            }
+            const markedStaleOn = yield this.getLabelCreationDate(issue, staleLabel);
+            const issueHasComments = yield this.isIssueStillStale(issue, markedStaleOn);
+            const issueHasUpdate = IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeClose);
+            core.debug(`Issue #${issue.number} marked stale on: ${markedStaleOn}`);
+            core.debug(`Issue #${issue.number} has been updated: ${issueHasUpdate}`);
+            core.debug(`Issue #${issue.number} has been commented on: ${issueHasComments}`);
+            if (!issueHasComments && !issueHasUpdate) {
+                core.debug(`Closing ${issueType} because it was last updated on ${issue.updated_at}`);
+                yield this.closeIssue(issue);
+            }
+            else {
+                if (this.options.removeStaleWhenUpdated) {
+                    yield this.removeLabel(issue, staleLabel);
+                }
+                core.debug(`Ignoring stale ${issueType} because it was updated recenlty`);
+            }
+        });
+    }
+    // checks to see if a given issue is still stale (has had activity on it)
+    isIssueStillStale(issue, sinceDate) {
+        return __awaiter(this, void 0, void 0, function* () {
+            core.debug(`Checking for comments on issue #${issue.number} since ${sinceDate} to see if it is still stale`);
+            if (!sinceDate) {
+                return true; // if no date was provided then the issue was marked stale a long time ago
+            }
+            this.operationsLeft -= 1;
+            // find any comments since the stale label
+            const comments = yield this.listIssueComments(issue.number, sinceDate);
+            // if there are any user comments returned, issue is not stale anymore
+            return comments.filter(comment => comment.user.type === 'User').length > 0;
+        });
+    }
+    // grab comments for an issue since a given date
+    listIssueComments(issueNumber, sinceDate) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // find any comments since date on the given issue
+            const comments = yield this.client.issues.listComments({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                issue_number: issueNumber,
+                since: sinceDate
+            });
+            return comments.data;
         });
     }
     // grab issues from github in baches of 100
@@ -8535,6 +8593,7 @@ class IssueProcessor {
         return __awaiter(this, void 0, void 0, function* () {
             core.debug(`Marking issue #${issue.number} - ${issue.title} as stale`);
             this.staleIssues.push(issue);
+            this.operationsLeft -= 2;
             if (this.options.debugOnly) {
                 return;
             }
@@ -8552,11 +8611,12 @@ class IssueProcessor {
             });
         });
     }
-    /// Close an issue based on staleness
+    // Close an issue based on staleness
     closeIssue(issue) {
         return __awaiter(this, void 0, void 0, function* () {
             core.debug(`Closing issue #${issue.number} - ${issue.title} for being stale`);
             this.closedIssues.push(issue);
+            this.operationsLeft -= 1;
             if (this.options.debugOnly) {
                 return;
             }
@@ -8568,13 +8628,47 @@ class IssueProcessor {
             });
         });
     }
+    // Remove a label from an issue
+    removeLabel(issue, label) {
+        return __awaiter(this, void 0, void 0, function* () {
+            core.debug(`Removing label ${label} from issue #${issue.number} - ${issue.title}`);
+            this.operationsLeft -= 1;
+            if (this.options.debugOnly) {
+                return;
+            }
+            yield this.client.issues.removeLabel({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                issue_number: issue.number,
+                name: encodeURIComponent(label) // A label can have a "?" in the name
+            });
+        });
+    }
+    // returns the creation date of a given label on an issue (or nothing if no label existed)
+    ///see https://developer.github.com/v3/activity/events/
+    getLabelCreationDate(issue, label) {
+        return __awaiter(this, void 0, void 0, function* () {
+            core.debug(`Checking for label ${label} on issue #${issue.number}`);
+            this.operationsLeft -= 1;
+            const options = this.client.issues.listEvents.endpoint.merge({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                per_page: 100,
+                issue_number: issue.number
+            });
+            const events = yield this.client.paginate(options);
+            const reversedEvents = events.reverse();
+            const staleLabeledEvent = reversedEvents.find(event => event.event === 'labeled' && event.label.name === label);
+            return staleLabeledEvent.created_at;
+        });
+    }
     static isLabeled(issue, label) {
         const labelComparer = l => label.localeCompare(l.name, undefined, { sensitivity: 'accent' }) === 0;
         return issue.labels.filter(labelComparer).length > 0;
     }
-    static wasLastUpdatedBefore(issue, num_days) {
+    static updatedSince(timestamp, num_days) {
         const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
-        const millisSinceLastUpdated = new Date().getTime() - new Date(issue.updated_at).getTime();
+        const millisSinceLastUpdated = new Date().getTime() - new Date(timestamp).getTime();
         return millisSinceLastUpdated >= daysInMillis;
     }
     static parseCommaSeparatedString(s) {

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -14,6 +14,14 @@ export interface Issue {
   locked: boolean;
 }
 
+export interface User {
+  type: string;
+}
+
+export interface Comment {
+  user: User;
+}
+
 export interface IssueEvent {
   created_at: string;
   event: string;
@@ -53,7 +61,12 @@ export class IssueProcessor {
 
   constructor(
     options: IssueProcessorOptions,
-    getIssues?: (page: number) => Promise<Issue[]>
+    getIssues?: (page: number) => Promise<Issue[]>,
+    listIssueComments?: (
+      issueNumber: number,
+      sinceDate: string
+    ) => Promise<Comment[]>,
+    getLabelCreationDate?: (issue: Issue, label: string) => Promise<string>
   ) {
     this.options = options;
     this.operationsLeft = options.operationsPerRun;
@@ -61,6 +74,14 @@ export class IssueProcessor {
 
     if (getIssues) {
       this.getIssues = getIssues;
+    }
+
+    if (listIssueComments) {
+      this.listIssueComments = listIssueComments;
+    }
+
+    if (getLabelCreationDate) {
+      this.getLabelCreationDate = getLabelCreationDate;
     }
 
     if (this.options.debugOnly) {
@@ -132,7 +153,10 @@ export class IssueProcessor {
         core.debug(`Found a stale ${issueType}`);
         await this.processStaleIssue(issue, issueType, staleLabel);
       } else if (
-        IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeStale)
+        IssueProcessor.updatedSince(
+          issue.updated_at,
+          this.options.daysBeforeStale
+        )
       ) {
         core.debug(
           `Marking ${issueType} stale because it was last updated on ${issue.updated_at}`
@@ -147,13 +171,23 @@ export class IssueProcessor {
   }
 
   // handle all of the stale issue logic when we find a stale issue
-  private async processStaleIssue(issue: Issue, issueType: string, staleLabel: string) {
+  private async processStaleIssue(
+    issue: Issue,
+    issueType: string,
+    staleLabel: string
+  ) {
     if (this.options.daysBeforeClose < 0) {
       return; // nothing to do because we aren't closing stale issues
     }
 
-    const markedStaleOn: string = await this.getLabelCreationDate(issue, staleLabel);
-    const issueHasComments: boolean = await this.isIssueStillStale(issue, markedStaleOn);
+    const markedStaleOn: string = await this.getLabelCreationDate(
+      issue,
+      staleLabel
+    );
+    const issueHasComments: boolean = await this.isIssueStillStale(
+      issue,
+      markedStaleOn
+    );
     const issueHasUpdate: boolean = IssueProcessor.updatedSince(
       issue.updated_at,
       this.options.daysBeforeClose
@@ -161,7 +195,9 @@ export class IssueProcessor {
 
     core.debug(`Issue #${issue.number} marked stale on: ${markedStaleOn}`);
     core.debug(`Issue #${issue.number} has been updated: ${issueHasUpdate}`);
-    core.debug(`Issue #${issue.number} has been commented on: ${issueHasComments}`);
+    core.debug(
+      `Issue #${issue.number} has been commented on: ${issueHasComments}`
+    );
 
     if (!issueHasComments && !issueHasUpdate) {
       core.debug(
@@ -172,10 +208,46 @@ export class IssueProcessor {
       if (this.options.removeStaleWhenUpdated) {
         await this.removeLabel(issue, staleLabel);
       }
-      core.debug(
-        `Ignoring stale ${issueType} because it was updated recenlty`
-      );
+      core.debug(`Ignoring stale ${issueType} because it was updated recenlty`);
     }
+  }
+
+  // checks to see if a given issue is still stale (has had activity on it)
+  private async isIssueStillStale(
+    issue: Issue,
+    sinceDate: string
+  ): Promise<boolean> {
+    core.debug(
+      `Checking for comments on issue #${issue.number} since ${sinceDate} to see if it is still stale`
+    );
+
+    if (!sinceDate) {
+      return true; // if no date was provided then the issue was marked stale a long time ago
+    }
+
+    this.operationsLeft -= 1;
+
+    // find any comments since the stale label
+    const comments = await this.listIssueComments(issue.number, sinceDate);
+
+    // if there are any user comments returned, issue is not stale anymore
+    return comments.filter(comment => comment.user.type === 'User').length > 0;
+  }
+
+  // grab comments for an issue since a given date
+  private async listIssueComments(
+    issueNumber: number,
+    sinceDate: string
+  ): Promise<Comment[]> {
+    // find any comments since date on the given issue
+    const comments = await this.client.issues.listComments({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      issue_number: issueNumber,
+      since: sinceDate
+    });
+
+    return comments.data;
   }
 
   // grab issues from github in baches of 100
@@ -247,51 +319,24 @@ export class IssueProcessor {
     });
   }
 
-    // Remove a label from an issue
-    private async removeLabel(issue: Issue, label: string): Promise<void> {
-      core.debug(
-        `Removing label ${label} from issue #${issue.number} - ${issue.title}`
-      );
-
-      this.operationsLeft -= 1;
-
-      if (this.options.debugOnly) {
-        return;
-      }
-
-      await this.client.issues.removeLabel({
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        issue_number: issue.number,
-        name: encodeURIComponent(label), // A label can have a "?" in the name
-      })
-    }
-
-  // checks to see if a given issue is still stale (has had activity on it)
-  private async isIssueStillStale(
-    issue: Issue,
-    sinceDate: string
-  ): Promise<boolean> {
+  // Remove a label from an issue
+  private async removeLabel(issue: Issue, label: string): Promise<void> {
     core.debug(
-      `Checking for comments on issue #${issue.number} since ${sinceDate} to see if it is still stale`
+      `Removing label ${label} from issue #${issue.number} - ${issue.title}`
     );
-
-    if (!sinceDate) {
-      return true; // if no date was provided then the issue was marked stale a long time ago
-    }
 
     this.operationsLeft -= 1;
 
-    // find any comments since the stale label
-    const comments = await this.client.issues.listComments({
+    if (this.options.debugOnly) {
+      return;
+    }
+
+    await this.client.issues.removeLabel({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
       issue_number: issue.number,
-      since: sinceDate
+      name: encodeURIComponent(label) // A label can have a "?" in the name
     });
-
-    // if there are any user comments returned, issue is not stale anymore
-    return comments.data.filter(comment => comment.user.type === "User").length > 0
   }
 
   // returns the creation date of a given label on an issue (or nothing if no label existed)
@@ -300,9 +345,7 @@ export class IssueProcessor {
     issue: Issue,
     label: string
   ): Promise<string> {
-    core.debug(
-      `Checking for label ${label} on issue #${issue.number}`
-    );
+    core.debug(`Checking for label ${label} on issue #${issue.number}`);
 
     this.operationsLeft -= 1;
 
@@ -311,16 +354,16 @@ export class IssueProcessor {
       repo: github.context.repo.repo,
       per_page: 100,
       issue_number: issue.number
-    })
+    });
 
     const events: IssueEvent[] = await this.client.paginate(options);
     const reversedEvents = events.reverse();
 
     const staleLabeledEvent = reversedEvents.find(
-      event => event.event === "labeled" && event.label.name === label
+      event => event.event === 'labeled' && event.label.name === label
     );
 
-    return staleLabeledEvent!.created_at
+    return staleLabeledEvent!.created_at;
   }
 
   private static isLabeled(issue: Issue, label: string): boolean {

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -153,7 +153,7 @@ export class IssueProcessor {
         core.debug(`Found a stale ${issueType}`);
         await this.processStaleIssue(issue, issueType, staleLabel);
       } else if (
-        IssueProcessor.updatedSince(
+        !IssueProcessor.updatedSince(
           issue.updated_at,
           this.options.daysBeforeStale
         )
@@ -188,6 +188,7 @@ export class IssueProcessor {
       issue,
       markedStaleOn
     );
+
     const issueHasUpdate: boolean = IssueProcessor.updatedSince(
       issue.updated_at,
       this.options.daysBeforeClose
@@ -376,7 +377,8 @@ export class IssueProcessor {
     const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
     const millisSinceLastUpdated =
       new Date().getTime() - new Date(timestamp).getTime();
-    return millisSinceLastUpdated >= daysInMillis;
+
+    return millisSinceLastUpdated < daysInMillis;
   }
 
   private static parseCommaSeparatedString(s: string): string[] {

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -14,6 +14,12 @@ export interface Issue {
   locked: boolean;
 }
 
+export interface IssueEvent {
+  created_at: string;
+  event: string;
+  label: Label;
+}
+
 export interface Label {
   name: string;
 }
@@ -30,6 +36,7 @@ export interface IssueProcessorOptions {
   exemptPrLabels: string;
   onlyLabels: string;
   operationsPerRun: number;
+  removeStaleWhenUpdated: boolean;
   debugOnly: boolean;
 }
 
@@ -123,25 +130,9 @@ export class IssueProcessor {
 
       if (IssueProcessor.isLabeled(issue, staleLabel)) {
         core.debug(`Found a stale ${issueType}`);
-        if (
-          this.options.daysBeforeClose >= 0 &&
-          IssueProcessor.wasLastUpdatedBefore(
-            issue,
-            this.options.daysBeforeClose
-          )
-        ) {
-          core.debug(
-            `Closing ${issueType} because it was last updated on ${issue.updated_at}`
-          );
-          await this.closeIssue(issue);
-          this.operationsLeft -= 1;
-        } else {
-          core.debug(
-            `Ignoring stale ${issueType} because it was updated recenlty`
-          );
-        }
+        await this.processStaleIssue(issue, issueType, staleLabel);
       } else if (
-        IssueProcessor.wasLastUpdatedBefore(issue, this.options.daysBeforeStale)
+        IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeStale)
       ) {
         core.debug(
           `Marking ${issueType} stale because it was last updated on ${issue.updated_at}`
@@ -153,6 +144,38 @@ export class IssueProcessor {
 
     // do the next batch
     return this.processIssues(page + 1);
+  }
+
+  // handle all of the stale issue logic when we find a stale issue
+  private async processStaleIssue(issue: Issue, issueType: string, staleLabel: string) {
+    if (this.options.daysBeforeClose < 0) {
+      return; // nothing to do because we aren't closing stale issues
+    }
+
+    const markedStaleOn: string = await this.getLabelCreationDate(issue, staleLabel);
+    const issueHasComments: boolean = await this.isIssueStillStale(issue, markedStaleOn);
+    const issueHasUpdate: boolean = IssueProcessor.updatedSince(
+      issue.updated_at,
+      this.options.daysBeforeClose
+    );
+
+    core.debug(`Issue #${issue.number} marked stale on: ${markedStaleOn}`);
+    core.debug(`Issue #${issue.number} has been updated: ${issueHasUpdate}`);
+    core.debug(`Issue #${issue.number} has been commented on: ${issueHasComments}`);
+
+    if (!issueHasComments && !issueHasUpdate) {
+      core.debug(
+        `Closing ${issueType} because it was last updated on ${issue.updated_at}`
+      );
+      await this.closeIssue(issue);
+    } else {
+      if (this.options.removeStaleWhenUpdated) {
+        await this.removeLabel(issue, staleLabel);
+      }
+      core.debug(
+        `Ignoring stale ${issueType} because it was updated recenlty`
+      );
+    }
   }
 
   // grab issues from github in baches of 100
@@ -181,6 +204,8 @@ export class IssueProcessor {
 
     this.staleIssues.push(issue);
 
+    this.operationsLeft -= 2;
+
     if (this.options.debugOnly) {
       return;
     }
@@ -200,13 +225,15 @@ export class IssueProcessor {
     });
   }
 
-  /// Close an issue based on staleness
+  // Close an issue based on staleness
   private async closeIssue(issue: Issue): Promise<void> {
     core.debug(
       `Closing issue #${issue.number} - ${issue.title} for being stale`
     );
 
     this.closedIssues.push(issue);
+
+    this.operationsLeft -= 1;
 
     if (this.options.debugOnly) {
       return;
@@ -220,16 +247,92 @@ export class IssueProcessor {
     });
   }
 
+    // Remove a label from an issue
+    private async removeLabel(issue: Issue, label: string): Promise<void> {
+      core.debug(
+        `Removing label ${label} from issue #${issue.number} - ${issue.title}`
+      );
+
+      this.operationsLeft -= 1;
+
+      if (this.options.debugOnly) {
+        return;
+      }
+
+      await this.client.issues.removeLabel({
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        issue_number: issue.number,
+        name: encodeURIComponent(label), // A label can have a "?" in the name
+      })
+    }
+
+  // checks to see if a given issue is still stale (has had activity on it)
+  private async isIssueStillStale(
+    issue: Issue,
+    sinceDate: string
+  ): Promise<boolean> {
+    core.debug(
+      `Checking for comments on issue #${issue.number} since ${sinceDate} to see if it is still stale`
+    );
+
+    if (!sinceDate) {
+      return true; // if no date was provided then the issue was marked stale a long time ago
+    }
+
+    this.operationsLeft -= 1;
+
+    // find any comments since the stale label
+    const comments = await this.client.issues.listComments({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      issue_number: issue.number,
+      since: sinceDate
+    });
+
+    // if there are any user comments returned, issue is not stale anymore
+    return comments.data.filter(comment => comment.user.type === "User").length > 0
+  }
+
+  // returns the creation date of a given label on an issue (or nothing if no label existed)
+  ///see https://developer.github.com/v3/activity/events/
+  private async getLabelCreationDate(
+    issue: Issue,
+    label: string
+  ): Promise<string> {
+    core.debug(
+      `Checking for label ${label} on issue #${issue.number}`
+    );
+
+    this.operationsLeft -= 1;
+
+    const options = this.client.issues.listEvents.endpoint.merge({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      per_page: 100,
+      issue_number: issue.number
+    })
+
+    const events: IssueEvent[] = await this.client.paginate(options);
+    const reversedEvents = events.reverse();
+
+    const staleLabeledEvent = reversedEvents.find(
+      event => event.event === "labeled" && event.label.name === label
+    );
+
+    return staleLabeledEvent!.created_at
+  }
+
   private static isLabeled(issue: Issue, label: string): boolean {
     const labelComparer: (l: Label) => boolean = l =>
       label.localeCompare(l.name, undefined, {sensitivity: 'accent'}) === 0;
     return issue.labels.filter(labelComparer).length > 0;
   }
 
-  private static wasLastUpdatedBefore(issue: Issue, num_days: number): boolean {
+  private static updatedSince(timestamp: string, num_days: number): boolean {
     const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
     const millisSinceLastUpdated =
-      new Date().getTime() - new Date(issue.updated_at).getTime();
+      new Date().getTime() - new Date(timestamp).getTime();
     return millisSinceLastUpdated >= daysInMillis;
   }
 

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -58,6 +58,7 @@ export class IssueProcessor {
 
   readonly staleIssues: Issue[] = [];
   readonly closedIssues: Issue[] = [];
+  readonly removedLabelIssues: Issue[] = [];
 
   constructor(
     options: IssueProcessorOptions,
@@ -325,6 +326,8 @@ export class IssueProcessor {
     core.debug(
       `Removing label ${label} from issue #${issue.number} - ${issue.title}`
     );
+
+    this.removedLabelIssues.push(issue);
 
     this.operationsLeft -= 1;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,7 @@ function getAndValidateArgs(): IssueProcessorOptions {
     operationsPerRun: parseInt(
       core.getInput('operations-per-run', {required: true})
     ),
+    removeStaleWhenUpdated: core.getInput('remove-stale-when-updated') === 'true',
     debugOnly: core.getInput('debug-only') === 'true'
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,8 @@ function getAndValidateArgs(): IssueProcessorOptions {
     operationsPerRun: parseInt(
       core.getInput('operations-per-run', {required: true})
     ),
-    removeStaleWhenUpdated: core.getInput('remove-stale-when-updated') === 'true',
+    removeStaleWhenUpdated:
+      core.getInput('remove-stale-when-updated') === 'true',
     debugOnly: core.getInput('debug-only') === 'true'
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,8 +32,9 @@ function getAndValidateArgs(): IssueProcessorOptions {
     operationsPerRun: parseInt(
       core.getInput('operations-per-run', {required: true})
     ),
-    removeStaleWhenUpdated:
-      core.getInput('remove-stale-when-updated') === 'true',
+    removeStaleWhenUpdated: !(
+      core.getInput('remove-stale-when-updated') === 'false'
+    ),
     debugOnly: core.getInput('debug-only') === 'true'
   };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    //"sourceMap": true
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
### Addresses #21: Ignore issues that have comments on them

* Check each issue for comments since the stale label was applied. If they exist, don't close the issue.
* Add an option to allow the stale label to be removed by the bot (off by default)

### TODO:
1. [x] Fix failing tests
2. [ ] (optional) Make the method injection for the test suite less burdensome (mocking or a fake client)
3. [x] Add more tests
4. [x] Test this logic on some real repos