### PR TITLE
Fix minor issues regarding counting of operations

### DIFF
--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -97,11 +97,6 @@ export class IssueProcessor {
   }
 
   async processIssues(page: number = 1): Promise<number> {
-    if (this.operationsLeft <= 0) {
-      core.warning('Reached max number of operations to process. Exiting.');
-      return 0;
-    }
-
     // get the next batch of issues
     const issues: Issue[] = await this.getIssues(page);
     this.operationsLeft -= 1;
@@ -176,6 +171,11 @@ export class IssueProcessor {
       if (isStale) {
         core.debug(`Found a stale ${issueType}`);
         await this.processStaleIssue(issue, issueType, staleLabel);
+      }
+
+      if (this.operationsLeft <= 0) {
+        core.warning('Reached max number of operations to process. Exiting.');
+        return 0;
       }
     }
 

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -169,7 +169,6 @@ export class IssueProcessor {
           `Marking ${issueType} stale because it was last updated on ${issue.updated_at} and it does not have a stale label`
         );
         await this.markStale(issue, staleMessage, staleLabel);
-        this.operationsLeft -= 2;
         isStale = true; // this issue is now considered stale
       }
 


### PR DESCRIPTION
This addresses two minor issues regarding how operations are counted, regarding the `operations-per-run` parameter:

- Count markStale() as 2 operations rather than 4.
- Evaluate after each processed issue whether there are operations left, rather than after each page of issues.

I commented these observations in https://github.com/actions/stale/issues/79#issuecomment-633510698.