### PR TITLE
Update logging to be info level, fix un-staling of issues

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -595,3 +595,33 @@ test('stale issues should be closed if the closed nubmer of days (additive) is a
   expect(processor.closedIssues.length).toEqual(1);
   expect(processor.staleIssues.length).toEqual(0);
 });
+
+test('stale issues should not be closed until after the closed number of days (long)', async () => {
+  let lastUpdate = new Date();
+  lastUpdate.setDate(lastUpdate.getDate() - 10);
+  const TestIssueList: Issue[] = [
+    generateIssue(
+      1,
+      'An issue that should be marked stale but not closed',
+      lastUpdate.toString(),
+      false
+    )
+  ];
+
+  const opts = DefaultProcessorOptions;
+  opts.daysBeforeStale = 5; // stale after 5 days
+  opts.daysBeforeClose = 20; // closes after 25 days
+
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.closedIssues.length).toEqual(0);
+  expect(processor.staleIssues.length).toEqual(1);
+});

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -426,6 +426,7 @@ test('exempt issue labels will not be marked stale (multi issue label)', async (
 
   expect(processor.staleIssues.length).toEqual(0);
   expect(processor.closedIssues.length).toEqual(0);
+  expect(processor.removedLabelIssues.length).toEqual(0);
 });
 
 test('exempt pr labels will not be marked stale', async () => {
@@ -474,6 +475,7 @@ test('stale issues should not be closed if days is set to -1', async () => {
   await processor.processIssues(1);
 
   expect(processor.closedIssues.length).toEqual(0);
+  expect(processor.removedLabelIssues.length).toEqual(0);
 });
 
 test('stale label should be removed if a comment was added to a stale issue', async () => {
@@ -562,6 +564,7 @@ test('stale issues should not be closed until after the closed number of days', 
   await processor.processIssues(1);
 
   expect(processor.closedIssues.length).toEqual(0);
+  expect(processor.removedLabelIssues.length).toEqual(0);
   expect(processor.staleIssues.length).toEqual(1);
 });
 
@@ -593,6 +596,7 @@ test('stale issues should be closed if the closed nubmer of days (additive) is a
   await processor.processIssues(1);
 
   expect(processor.closedIssues.length).toEqual(1);
+  expect(processor.removedLabelIssues.length).toEqual(0);
   expect(processor.staleIssues.length).toEqual(0);
 });
 
@@ -623,5 +627,6 @@ test('stale issues should not be closed until after the closed number of days (l
   await processor.processIssues(1);
 
   expect(processor.closedIssues.length).toEqual(0);
+  expect(processor.removedLabelIssues.length).toEqual(0);
   expect(processor.staleIssues.length).toEqual(1);
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -8514,7 +8514,6 @@ class IssueProcessor {
                 let isStale = IssueProcessor.isLabeled(issue, staleLabel);
                 // should this issue be marked stale?
                 const shouldBeStale = !IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeStale);
-                // TODO: better stale calculation here not including bot comments
                 // determine if this issue needs to be marked stale first
                 if (!isStale && shouldBeStale) {
                     core.info(`Marking ${issueType} stale because it was last updated on ${issue.updated_at} and it does not have a stale label`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8471,10 +8471,6 @@ class IssueProcessor {
     }
     processIssues(page = 1) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (this.operationsLeft <= 0) {
-                core.warning('Reached max number of operations to process. Exiting.');
-                return 0;
-            }
             // get the next batch of issues
             const issues = yield this.getIssues(page);
             this.operationsLeft -= 1;
@@ -8518,7 +8514,6 @@ class IssueProcessor {
                 if (!isStale && shouldBeStale) {
                     core.info(`Marking ${issueType} stale because it was last updated on ${issue.updated_at} and it does not have a stale label`);
                     yield this.markStale(issue, staleMessage, staleLabel);
-                    this.operationsLeft -= 2;
                     isStale = true; // this issue is now considered stale
                 }
                 // process the issue if it was marked stale
@@ -8526,6 +8521,10 @@ class IssueProcessor {
                     core.info(`Found a stale ${issueType}`);
                     yield this.processStaleIssue(issue, issueType, staleLabel);
                 }
+            }
+            if (this.operationsLeft <= 0) {
+                core.warning('Reached max number of operations to process. Exiting.');
+                return 0;
             }
             // do the next batch
             return this.processIssues(page + 1);
@@ -8566,7 +8565,6 @@ class IssueProcessor {
             if (!sinceDate) {
                 return true;
             }
-            this.operationsLeft -= 1;
             // find any comments since the date
             const comments = yield this.listIssueComments(issue.number, sinceDate);
             const filteredComments = comments.filter(comment => comment.user.type === 'User' &&

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -163,8 +163,6 @@ export class IssueProcessor {
         this.options.daysBeforeStale
       );
 
-      // TODO: better stale calculation here not including bot comments
-
       // determine if this issue needs to be marked stale first
       if (!isStale && shouldBeStale) {
         core.info(


### PR DESCRIPTION
* The bot would un-stale issues because of how it checked staleness
* Made logging info by default so its easier to troubleshoot customer issues/runs
* Updated operation counts