### PR TITLE
Update issue.updated_at if we have just marked an issue stale

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -62,10 +62,35 @@ test('empty issue list results in 1 operation', async () => {
   expect(operationsLeft).toEqual(99);
 });
 
-test('processing an issue with no label will make it stale and close it, if it is old enough', async () => {
+test('processing an issue with no label will make it stale and close it, if it is old enough only if days-before-close is set to 0', async () => {
   const TestIssueList: Issue[] = [
     generateIssue(1, 'An issue with no label', '2020-01-01T17:00:00Z')
   ];
+
+  const opts = {...DefaultProcessorOptions};
+  opts.daysBeforeClose = 0;
+
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(1);
+  expect(processor.closedIssues.length).toEqual(1);
+});
+
+test('processing an issue with no label will make it stale and not close it if days-before-close is set to > 0', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'An issue with no label', '2020-01-01T17:00:00Z')
+  ];
+
+  const opts = {...DefaultProcessorOptions};
+  opts.daysBeforeClose = 15;
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
@@ -78,7 +103,7 @@ test('processing an issue with no label will make it stale and close it, if it i
   await processor.processIssues(1);
 
   expect(processor.staleIssues.length).toEqual(1);
-  expect(processor.closedIssues.length).toEqual(1);
+  expect(processor.closedIssues.length).toEqual(0);
 });
 
 test('processing an issue with no label will make it stale but not close it', async () => {

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -304,6 +304,20 @@ export class IssueProcessor {
 
     this.operationsLeft -= 2;
 
+    // We are about to modify the issue by adding a comment and applying a label, so update the modification timestamp
+    // to `days-before-stale` days ago to simulate as if we marked this issue stale on the very first day it actually
+    // became stale. This has the effect of respecting `days-before-close` no matter what value it is set to. The user
+    // can request to close the issue immediately by using `days-before-close` === 0, or they can set it to any number
+    // of days to wait before actually closing the issue.
+    const daysBeforeStaleInMillis =
+      1000 * 60 * 60 * 24 * this.options.daysBeforeStale;
+    const newUpdatedAtDate: Date = new Date();
+    newUpdatedAtDate.setTime(
+      newUpdatedAtDate.getTime() - daysBeforeStaleInMillis
+    );
+
+    issue.updated_at = newUpdatedAtDate.toString();
+
     if (this.options.debugOnly) {
       return;
     }
@@ -410,7 +424,7 @@ export class IssueProcessor {
     const millisSinceLastUpdated =
       new Date().getTime() - new Date(timestamp).getTime();
 
-    return millisSinceLastUpdated < daysInMillis;
+    return millisSinceLastUpdated <= daysInMillis;
   }
 
   private static parseCommaSeparatedString(s: string): string[] {


### PR DESCRIPTION
This is to ensure we do not close issues before days-before-close has
expired. Without this fix we can encounter a situation where an issue
gets marked as stale and it gets closed immediately without waiting
days-before-close number of days.

If the user still wishes to close the issue immediately after marking
it stale they have the option of doing so by setting days-before-close
to 0 to get the desired effect.

Fixes: #84