### PR TITLE
Add optional Close Message

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Jest Tests",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/node_modules/jest/bin/jest",
+            "args": [
+                "-i"
+            ],
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "internalConsoleOptions": "openOnSessionStart",
+            "console": "integratedTerminal",
+            "outFiles": [
+                "${workspaceRoot}/build/dist/**/*"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Message to comment on stale issues. If none provided, will not mark issues stale'
@@ -52,7 +52,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
@@ -71,7 +71,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'
@@ -84,4 +84,4 @@ jobs:
 
 ### Debugging
 
-To see debug ouput from this action, you must set the secret `ACTIONS_STEP_DEBUG` to `true` in your repository. You can run this action in debug only mode (no actions will be taken on your issues) by passing `debug-only` `true` as an argument to the action.
+To see debug output from this action, you must set the secret `ACTIONS_STEP_DEBUG` to `true` in your repository. You can run this action in debug only mode (no actions will be taken on your issues) by passing `debug-only` `true` as an argument to the action.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
         exempt-issue-labels: 'awaiting-approval,work-in-progress'
         stale-pr-label: 'no-pr-activity'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Warns and then closes issues and PRs that have had no activity for a specified amount of time.
 
+### Building and testing
+
+Install the dependencies  
+```bash
+$ npm install
+```
+
+Build the typescript and package it for distribution
+```bash
+$ npm run build && npm run pack
+```
+
+Run the tests :heavy_check_mark:  
+```bash
+$ npm test
+```
+
 ### Usage
 
 See [action.yml](./action.yml) For comprehensive list of options.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1.1.0
+    - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Message to comment on stale issues. If none provided, will not mark issues stale'
@@ -52,7 +52,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1.1.0
+    - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
@@ -71,7 +71,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1.1.0
+    - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -43,11 +43,17 @@ const DefaultProcessorOptions: IssueProcessorOptions = {
   exemptPrLabels: '',
   onlyLabels: '',
   operationsPerRun: 100,
-  debugOnly: true
+  debugOnly: true,
+  removeStaleWhenUpdated: false
 };
 
 test('empty issue list results in 1 operation', async () => {
-  const processor = new IssueProcessor(DefaultProcessorOptions, async () => []);
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async () => [],
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
+  );
 
   // process our fake issue list
   const operationsLeft = await processor.processIssues(1);
@@ -58,11 +64,14 @@ test('empty issue list results in 1 operation', async () => {
 
 test('processing an issue with no label will make it stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z')
+    generateIssue(1, 'An issue with no label', '2020-01-01T17:00:00Z')
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -74,11 +83,20 @@ test('processing an issue with no label will make it stale', async () => {
 
 test('processing a stale issue will close it', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'])
+    generateIssue(
+      1,
+      'A stale issue that should be closed',
+      '2020-01-01T17:00:00Z',
+      false,
+      ['Stale']
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -90,11 +108,20 @@ test('processing a stale issue will close it', async () => {
 
 test('processing a stale PR will close it', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'])
+    generateIssue(
+      1,
+      'A stale PR that should be closed',
+      '2020-01-01T17:00:00Z',
+      true,
+      ['Stale']
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -106,11 +133,20 @@ test('processing a stale PR will close it', async () => {
 
 test('closed issues will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, [], true)
+    generateIssue(
+      1,
+      'A closed issue that will not be marked',
+      '2020-01-01T17:00:00Z',
+      false,
+      [],
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => []
   );
 
   // process our fake issue list
@@ -122,11 +158,21 @@ test('closed issues will not be marked stale', async () => {
 
 test('stale closed issues will not be closed', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'], true)
+    generateIssue(
+      1,
+      'A stale closed issue',
+      '2020-01-01T17:00:00Z',
+      false,
+      ['Stale'],
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -138,11 +184,21 @@ test('stale closed issues will not be closed', async () => {
 
 test('closed prs will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, [], true)
+    generateIssue(
+      1,
+      'A closed PR that will not be marked',
+      '2020-01-01T17:00:00Z',
+      true,
+      [],
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -154,11 +210,21 @@ test('closed prs will not be marked stale', async () => {
 
 test('stale closed prs will not be closed', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'], true)
+    generateIssue(
+      1,
+      'A stale closed PR that will not be closed again',
+      '2020-01-01T17:00:00Z',
+      true,
+      ['Stale'],
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -170,7 +236,15 @@ test('stale closed prs will not be closed', async () => {
 
 test('locked issues will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, [], false, true)
+    generateIssue(
+      1,
+      'A locked issue that will not be stale',
+      '2020-01-01T17:00:00Z',
+      false,
+      [],
+      false,
+      true
+    )
   ];
 
   const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
@@ -186,11 +260,22 @@ test('locked issues will not be marked stale', async () => {
 
 test('stale locked issues will not be closed', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'], false, true)
+    generateIssue(
+      1,
+      'A stale locked issue that will not be closed',
+      '2020-01-01T17:00:00Z',
+      false,
+      ['Stale'],
+      false,
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -202,7 +287,15 @@ test('stale locked issues will not be closed', async () => {
 
 test('locked prs will not be marked stale', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, [], false, true)
+    generateIssue(
+      1,
+      'A locked PR that will not be marked stale',
+      '2020-01-01T17:00:00Z',
+      true,
+      [],
+      false,
+      true
+    )
   ];
 
   const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
@@ -218,11 +311,22 @@ test('locked prs will not be marked stale', async () => {
 
 test('stale locked prs will not be closed', async () => {
   const TestIssueList: Issue[] = [
-    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'], false, true)
+    generateIssue(
+      1,
+      'A stale locked PR that will not be closed',
+      '2020-01-01T17:00:00Z',
+      true,
+      ['Stale'],
+      false,
+      true
+    )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -239,11 +343,14 @@ test('exempt issue labels will not be marked stale', async () => {
     ])
   ];
 
-  let opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.exemptIssueLabels = 'Exempt';
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -258,11 +365,14 @@ test('exempt issue labels will not be marked stale (multi issue label with space
     generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Cool'])
   ];
 
-  let opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.exemptIssueLabels = 'Exempt, Cool, None';
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -277,11 +387,14 @@ test('exempt issue labels will not be marked stale (multi issue label)', async (
     generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Cool'])
   ];
 
-  let opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.exemptIssueLabels = 'Exempt,Cool,None';
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -298,11 +411,14 @@ test('exempt pr labels will not be marked stale', async () => {
     generateIssue(3, 'Another issue', '2020-01-01T17:00:00Z', false)
   ];
 
-  let opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.exemptIssueLabels = 'Cool';
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
@@ -320,15 +436,47 @@ test('stale issues should not be closed if days is set to -1', async () => {
     generateIssue(3, 'Another issue', '2020-01-01T17:00:00Z', false, ['Stale'])
   ];
 
-  let opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.daysBeforeClose = -1;
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
   );
 
   // process our fake issue list
   await processor.processIssues(1);
 
   expect(processor.closedIssues.length).toEqual(0);
+});
+
+test('stale label should be removed if a comment was added to a stale issue', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(
+      1,
+      'An issue that should un-stale',
+      '2020-01-01T17:00:00Z',
+      false,
+      ['Stale']
+    )
+  ];
+
+  const opts = DefaultProcessorOptions;
+  opts.removeStaleWhenUpdated = true;
+
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [{user: {type: 'User'}}], // return a fake comment so indicate there was an update
+    async (issue, label) => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.closedIssues.length).toEqual(0);
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.removedLabelIssues.length).toEqual(1);
 });

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -14,7 +14,9 @@ function generateIssue(
   title: string,
   updatedAt: string,
   isPullRequest: boolean = false,
-  labels: string[] = []
+  labels: string[] = [],
+  isClosed: boolean = false,
+  isLocked: boolean = false
 ): Issue {
   return {
     number: id,
@@ -23,7 +25,9 @@ function generateIssue(
     }),
     title: title,
     updated_at: updatedAt,
-    pull_request: isPullRequest ? {} : null
+    pull_request: isPullRequest ? {} : null,
+    state: isClosed ? 'closed' : 'open',
+    locked: isLocked
   };
 }
 
@@ -98,6 +102,134 @@ test('processing a stale PR will close it', async () => {
 
   expect(processor.staleIssues.length).toEqual(0);
   expect(processor.closedIssues.length).toEqual(1);
+});
+
+test('closed issues will not be marked stale', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, [], true)
+  ];
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
+});
+
+test('stale closed issues will not be closed', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'], true)
+  ];
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
+});
+
+test('closed prs will not be marked stale', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, [], true)
+  ];
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
+});
+
+test('stale closed prs will not be closed', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'], true)
+  ];
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
+});
+
+test('locked issues will not be marked stale', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, [], false, true)
+  ];
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
+});
+
+test('stale locked issues will not be closed', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, ['Stale'], false, true)
+  ];
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
+});
+
+test('locked prs will not be marked stale', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, [], false, true)
+  ];
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
+});
+
+test('stale locked prs will not be closed', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale'], false, true)
+  ];
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
 });
 
 test('exempt issue labels will not be marked stale', async () => {

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -178,3 +178,25 @@ test('exempt pr labels will not be marked stale', async () => {
 
   expect(processor.staleIssues.length).toEqual(2); // PR should get processed even though it has an exempt **issue** label
 });
+
+test('stale issues should not be closed if days is set to -1', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'My first issue', '2020-01-01T17:00:00Z', false, [
+      'Stale'
+    ]),
+    generateIssue(2, 'My first PR', '2020-01-01T17:00:00Z', true, ['Stale']),
+    generateIssue(3, 'Another issue', '2020-01-01T17:00:00Z', false, ['Stale'])
+  ];
+
+  let opts = DefaultProcessorOptions;
+  opts.daysBeforeClose = -1;
+
+  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
+    p == 1 ? TestIssueList : []
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.closedIssues.length).toEqual(0);
+});

--- a/action.yml
+++ b/action.yml
@@ -19,13 +19,13 @@ inputs:
     description: 'The label to apply when an issue is stale.'
     default: 'Stale'
   exempt-issue-labels:
-    description: 'The labels to apply when an issue is exempt from being marked stale. Separate multiple labels with commas (eg. label1,label2)'
+    description: 'The labels to apply when an issue is exempt from being marked stale. Separate multiple labels with commas (eg. "label1,label2")'
     default: ''
   stale-pr-label:
     description: 'The label to apply when a pull request is stale.'
     default: 'Stale'
   exempt-pr-labels:
-    description: 'The labels to apply when a pull request is exempt from being marked stale. Separate multiple labels with commas (eg. "label1,label2")''
+    description: 'The labels to apply when a pull request is exempt from being marked stale. Separate multiple labels with commas (eg. "label1,label2")'
     default: ''
   only-labels:
     description: 'Only issues or pull requests with all of these labels are checked if stale. Defaults to `[]` (disabled) and can be a comma-separated list of labels.'

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   operations-per-run:
     description: 'The maximum number of operations per run, used to control rate limiting.'
     default: 30
+  remove-stale-when-updated:
+    description: 'Remove stale labels from issues when they are updated or commented on.'
+    default: true
   debug-only:
     description: 'Run the processor in debug mode without actually performing any operations on live issues.'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -3536,6 +3536,8 @@ function getAndValidateArgs() {
         repoToken: core.getInput('repo-token', { required: true }),
         staleIssueMessage: core.getInput('stale-issue-message'),
         stalePrMessage: core.getInput('stale-pr-message'),
+        closeIssueMessage: core.getInput('close-issue-message'),
+        closePrMessage: core.getInput('close-pr-message'),
         daysBeforeStale: parseInt(core.getInput('days-before-stale', { required: true })),
         daysBeforeClose: parseInt(core.getInput('days-before-close', { required: true })),
         staleIssueLabel: core.getInput('stale-issue-label', { required: true }),
@@ -3596,7 +3598,7 @@ exports.getUserAgent = getUserAgent;
 /***/ 215:
 /***/ (function(module) {
 
-module.exports = {"_args":[["@octokit/rest@16.43.1","/Users/pjquirk/Source/GitHub/pjquirk/stale"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{"@octokit/types":"2.8.2","deprecation":"2.3.1","once":"1.4.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/","/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/Users/pjquirk/Source/GitHub/pjquirk/stale","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
+module.exports = {"_args":[["@octokit/rest@16.43.1","/Users/chocrates/workspace/stale"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{"@octokit/types":"2.8.2","deprecation":"2.3.1","once":"1.4.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/","/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/Users/chocrates/workspace/stale","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
 
 /***/ }),
 
@@ -8667,6 +8669,10 @@ class IssueProcessor {
                 const staleMessage = isPr
                     ? this.options.stalePrMessage
                     : this.options.staleIssueMessage;
+                const closeMessage = isPr
+                    ? this.options.closePrMessage
+                    : this.options.closeIssueMessage;
+                core.debug(`Close Message: ${closeMessage}`);
                 const staleLabel = isPr
                     ? this.options.stalePrLabel
                     : this.options.staleIssueLabel;
@@ -8689,19 +8695,19 @@ class IssueProcessor {
                     continue; // don't process exempt issues
                 }
                 // does this issue have a stale label?
-                let isStale = IssueProcessor.isLabeled(issue, staleLabel);
+                const isStale = IssueProcessor.isLabeled(issue, staleLabel);
                 // determine if this issue needs to be marked stale first
                 if (!isStale &&
                     !IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeStale)) {
                     core.debug(`Marking ${issueType} stale because it was last updated on ${issue.updated_at} and it does not have a stale label`);
                     yield this.markStale(issue, staleMessage, staleLabel);
                     this.operationsLeft -= 2;
-                    isStale = true; // this issue is now considered stale
+                    continue; // If we just marked an issue stale we want to give users a chance to action them before closing
                 }
                 // process any issues marked stale (including the issue above, if it was marked)
                 if (isStale) {
                     core.debug(`Found a stale ${issueType}`);
-                    yield this.processStaleIssue(issue, issueType, staleLabel);
+                    yield this.processStaleIssue(issue, issueType, staleLabel, closeMessage);
                 }
             }
             // do the next batch
@@ -8709,7 +8715,7 @@ class IssueProcessor {
         });
     }
     // handle all of the stale issue logic when we find a stale issue
-    processStaleIssue(issue, issueType, staleLabel) {
+    processStaleIssue(issue, issueType, staleLabel, closeMessage) {
         return __awaiter(this, void 0, void 0, function* () {
             if (this.options.daysBeforeClose < 0) {
                 return; // nothing to do because we aren't closing stale issues
@@ -8727,7 +8733,7 @@ class IssueProcessor {
             core.debug(`Issue #${issue.number} has been commented on: ${issueHasComments}`);
             if (!issueHasComments && !issueHasUpdate) {
                 core.debug(`Closing ${issueType} because it was last updated on ${issue.updated_at}`);
-                yield this.closeIssue(issue);
+                yield this.closeIssue(issue, closeMessage);
             }
             else {
                 if (this.options.removeStaleWhenUpdated) {
@@ -8802,11 +8808,20 @@ class IssueProcessor {
         });
     }
     // Close an issue based on staleness
-    closeIssue(issue) {
+    closeIssue(issue, closeMessage) {
         return __awaiter(this, void 0, void 0, function* () {
             core.debug(`Closing issue #${issue.number} - ${issue.title} for being stale`);
             this.closedIssues.push(issue);
             this.operationsLeft -= 1;
+            core.debug(`Close Message: ${closeMessage}`);
+            if (closeMessage) {
+                yield this.client.issues.createComment({
+                    owner: github.context.repo.owner,
+                    repo: github.context.repo.repo,
+                    issue_number: issue.number,
+                    body: closeMessage
+                });
+            }
             if (this.options.debugOnly) {
                 return;
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3756,6 +3756,7 @@ function getAndValidateArgs() {
         exemptPrLabels: core.getInput('exempt-pr-labels'),
         onlyLabels: core.getInput('only-labels'),
         operationsPerRun: parseInt(core.getInput('operations-per-run', { required: true })),
+        removeStaleWhenUpdated: !(core.getInput('remove-stale-when-updated') === 'false'),
         debugOnly: core.getInput('debug-only') === 'true'
     };
     for (const numberInput of [
@@ -8447,15 +8448,22 @@ const github = __importStar(__webpack_require__(469));
  * Handle processing of issues for staleness/closure.
  */
 class IssueProcessor {
-    constructor(options, getIssues) {
+    constructor(options, getIssues, listIssueComments, getLabelCreationDate) {
         this.operationsLeft = 0;
         this.staleIssues = [];
         this.closedIssues = [];
+        this.removedLabelIssues = [];
         this.options = options;
         this.operationsLeft = options.operationsPerRun;
         this.client = new github.GitHub(options.repoToken);
         if (getIssues) {
             this.getIssues = getIssues;
+        }
+        if (listIssueComments) {
+            this.listIssueComments = listIssueComments;
+        }
+        if (getLabelCreationDate) {
+            this.getLabelCreationDate = getLabelCreationDate;
         }
         if (this.options.debugOnly) {
             core.warning('Executing in debug mode. Debug output will be written but no issues will be processed.');
@@ -8490,23 +8498,23 @@ class IssueProcessor {
                     core.debug(`Skipping ${issueType} due to empty stale message`);
                     continue;
                 }
+                if (issue.state === 'closed') {
+                    core.debug(`Skipping ${issueType} because it is closed`);
+                    continue; // don't process closed issues
+                }
+                if (issue.locked) {
+                    core.debug(`Skipping ${issueType} because it is locked`);
+                    continue; // don't process locked issues
+                }
                 if (exemptLabels.some((exemptLabel) => IssueProcessor.isLabeled(issue, exemptLabel))) {
                     core.debug(`Skipping ${issueType} because it has an exempt label`);
                     continue; // don't process exempt issues
                 }
                 if (IssueProcessor.isLabeled(issue, staleLabel)) {
                     core.debug(`Found a stale ${issueType}`);
-                    if (this.options.daysBeforeClose >= 0 &&
-                        IssueProcessor.wasLastUpdatedBefore(issue, this.options.daysBeforeClose)) {
-                        core.debug(`Closing ${issueType} because it was last updated on ${issue.updated_at}`);
-                        yield this.closeIssue(issue);
-                        this.operationsLeft -= 1;
-                    }
-                    else {
-                        core.debug(`Ignoring stale ${issueType} because it was updated recenlty`);
-                    }
+                    yield this.processStaleIssue(issue, issueType, staleLabel);
                 }
-                else if (IssueProcessor.wasLastUpdatedBefore(issue, this.options.daysBeforeStale)) {
+                else if (!IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeStale)) {
                     core.debug(`Marking ${issueType} stale because it was last updated on ${issue.updated_at}`);
                     yield this.markStale(issue, staleMessage, staleLabel);
                     this.operationsLeft -= 2;
@@ -8514,6 +8522,57 @@ class IssueProcessor {
             }
             // do the next batch
             return this.processIssues(page + 1);
+        });
+    }
+    // handle all of the stale issue logic when we find a stale issue
+    processStaleIssue(issue, issueType, staleLabel) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (this.options.daysBeforeClose < 0) {
+                return; // nothing to do because we aren't closing stale issues
+            }
+            const markedStaleOn = yield this.getLabelCreationDate(issue, staleLabel);
+            const issueHasComments = yield this.isIssueStillStale(issue, markedStaleOn);
+            const issueHasUpdate = IssueProcessor.updatedSince(issue.updated_at, this.options.daysBeforeClose);
+            core.debug(`Issue #${issue.number} marked stale on: ${markedStaleOn}`);
+            core.debug(`Issue #${issue.number} has been updated: ${issueHasUpdate}`);
+            core.debug(`Issue #${issue.number} has been commented on: ${issueHasComments}`);
+            if (!issueHasComments && !issueHasUpdate) {
+                core.debug(`Closing ${issueType} because it was last updated on ${issue.updated_at}`);
+                yield this.closeIssue(issue);
+            }
+            else {
+                if (this.options.removeStaleWhenUpdated) {
+                    yield this.removeLabel(issue, staleLabel);
+                }
+                core.debug(`Ignoring stale ${issueType} because it was updated recenlty`);
+            }
+        });
+    }
+    // checks to see if a given issue is still stale (has had activity on it)
+    isIssueStillStale(issue, sinceDate) {
+        return __awaiter(this, void 0, void 0, function* () {
+            core.debug(`Checking for comments on issue #${issue.number} since ${sinceDate} to see if it is still stale`);
+            if (!sinceDate) {
+                return true; // if no date was provided then the issue was marked stale a long time ago
+            }
+            this.operationsLeft -= 1;
+            // find any comments since the stale label
+            const comments = yield this.listIssueComments(issue.number, sinceDate);
+            // if there are any user comments returned, issue is not stale anymore
+            return comments.filter(comment => comment.user.type === 'User').length > 0;
+        });
+    }
+    // grab comments for an issue since a given date
+    listIssueComments(issueNumber, sinceDate) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // find any comments since date on the given issue
+            const comments = yield this.client.issues.listComments({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                issue_number: issueNumber,
+                since: sinceDate
+            });
+            return comments.data;
         });
     }
     // grab issues from github in baches of 100
@@ -8535,6 +8594,7 @@ class IssueProcessor {
         return __awaiter(this, void 0, void 0, function* () {
             core.debug(`Marking issue #${issue.number} - ${issue.title} as stale`);
             this.staleIssues.push(issue);
+            this.operationsLeft -= 2;
             if (this.options.debugOnly) {
                 return;
             }
@@ -8552,11 +8612,12 @@ class IssueProcessor {
             });
         });
     }
-    /// Close an issue based on staleness
+    // Close an issue based on staleness
     closeIssue(issue) {
         return __awaiter(this, void 0, void 0, function* () {
             core.debug(`Closing issue #${issue.number} - ${issue.title} for being stale`);
             this.closedIssues.push(issue);
+            this.operationsLeft -= 1;
             if (this.options.debugOnly) {
                 return;
             }
@@ -8568,14 +8629,49 @@ class IssueProcessor {
             });
         });
     }
+    // Remove a label from an issue
+    removeLabel(issue, label) {
+        return __awaiter(this, void 0, void 0, function* () {
+            core.debug(`Removing label ${label} from issue #${issue.number} - ${issue.title}`);
+            this.removedLabelIssues.push(issue);
+            this.operationsLeft -= 1;
+            if (this.options.debugOnly) {
+                return;
+            }
+            yield this.client.issues.removeLabel({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                issue_number: issue.number,
+                name: encodeURIComponent(label) // A label can have a "?" in the name
+            });
+        });
+    }
+    // returns the creation date of a given label on an issue (or nothing if no label existed)
+    ///see https://developer.github.com/v3/activity/events/
+    getLabelCreationDate(issue, label) {
+        return __awaiter(this, void 0, void 0, function* () {
+            core.debug(`Checking for label ${label} on issue #${issue.number}`);
+            this.operationsLeft -= 1;
+            const options = this.client.issues.listEvents.endpoint.merge({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                per_page: 100,
+                issue_number: issue.number
+            });
+            const events = yield this.client.paginate(options);
+            const reversedEvents = events.reverse();
+            const staleLabeledEvent = reversedEvents.find(event => event.event === 'labeled' && event.label.name === label);
+            return staleLabeledEvent.created_at;
+        });
+    }
     static isLabeled(issue, label) {
         const labelComparer = l => label.localeCompare(l.name, undefined, { sensitivity: 'accent' }) === 0;
         return issue.labels.filter(labelComparer).length > 0;
     }
-    static wasLastUpdatedBefore(issue, num_days) {
+    static updatedSince(timestamp, num_days) {
         const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
-        const millisSinceLastUpdated = new Date().getTime() - new Date(issue.updated_at).getTime();
-        return millisSinceLastUpdated >= daysInMillis;
+        const millisSinceLastUpdated = new Date().getTime() - new Date(timestamp).getTime();
+        return millisSinceLastUpdated < daysInMillis;
     }
     static parseCommaSeparatedString(s) {
         // String.prototype.split defaults to [''] when called on an empty string

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "@actions/http-client": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.7.tgz",
-      "integrity": "sha512-PY3ys/XH5WMekkHyZhYSa/scYvlE5T/TV/T++vABHuY5ZRgtiBZkn2L2tV5Pv/xDCl59lSZb9WwRuWExDyAsSg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
+      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
       "requires": {
         "tunnel": "0.0.6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-action",
-  "version": "2.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,53 +5,18 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.3.tgz",
-      "integrity": "sha512-Wp4xnyokakM45Uuj4WLUxdsa8fJjKVl1fDTsPbTEcTcuu0Nb26IPQbOtjmnfaCPGcaoPOOqId8H9NapZ8gii4w=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
+      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
     },
     "@actions/github": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.1.1.tgz",
-      "integrity": "sha512-kAgTGUx7yf5KQCndVeHSwCNZuDBvPyxm5xKTswW2lofugeuC1AZX73nUUVDNaysnM9aKFMHv9YCdVJbg7syEyA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.2.0.tgz",
+      "integrity": "sha512-9UAZqn8ywdR70n3GwVle4N8ALosQs4z50N7XMXrSTUVOmVpaBC5kE3TRTT7qQdi3OaQV24mjGuJZsHUmhD+ZXw==",
       "requires": {
         "@actions/http-client": "^1.0.3",
         "@octokit/graphql": "^4.3.1",
         "@octokit/rest": "^16.43.1"
-      },
-      "dependencies": {
-        "@octokit/request-error": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
-          "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
-          "requires": {
-            "@octokit/types": "^2.0.0",
-            "deprecation": "^2.0.0",
-            "once": "^1.4.0"
-          }
-        },
-        "@octokit/rest": {
-          "version": "16.43.1",
-          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
-          "integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
-          "requires": {
-            "@octokit/auth-token": "^2.4.0",
-            "@octokit/plugin-paginate-rest": "^1.1.1",
-            "@octokit/plugin-request-log": "^1.0.0",
-            "@octokit/plugin-rest-endpoint-methods": "2.4.0",
-            "@octokit/request": "^5.2.0",
-            "@octokit/request-error": "^1.0.2",
-            "atob-lite": "^2.0.0",
-            "before-after-hook": "^2.0.0",
-            "btoa-lite": "^1.0.0",
-            "deprecation": "^2.0.0",
-            "lodash.get": "^4.4.2",
-            "lodash.set": "^4.3.2",
-            "lodash.uniq": "^4.5.0",
-            "octokit-pagination-methods": "^1.1.0",
-            "once": "^1.4.0",
-            "universal-user-agent": "^4.0.0"
-          }
-        }
       }
     },
     "@actions/http-client": {
@@ -557,13 +522,23 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
-      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.4.0.tgz",
+      "integrity": "sha512-Du3hAaSROQ8EatmYoSAJjzAz3t79t9Opj/WY1zUgxVUGfIKn0AEjg+hlOLscF6fv6i/4y/CeUvsWgIfwMkTccw==",
       "requires": {
         "@octokit/request": "^5.3.0",
         "@octokit/types": "^2.0.0",
-        "universal-user-agent": "^4.0.0"
+        "universal-user-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "universal-user-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+          "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+          "requires": {
+            "os-name": "^3.1.0"
+          }
+        }
       }
     },
     "@octokit/plugin-paginate-rest": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stale-action",
-  "version": "2.0.0",
+  "version": "3.0.2",
   "private": true,
   "description": "Marks old issues and PRs as stale",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.3",
+    "@actions/core": "^1.2.4",
     "@actions/github": "^2.2.0",
     "@octokit/rest": "^16.43.1",
     "semver": "^6.1.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.2.3",
-    "@actions/github": "^2.1.1",
+    "@actions/github": "^2.2.0",
     "@octokit/rest": "^16.43.1",
     "semver": "^6.1.1"
   },

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -10,6 +10,8 @@ export interface Issue {
   updated_at: string;
   labels: Label[];
   pull_request: any;
+  state: string;
+  locked: boolean;
 }
 
 export interface Label {
@@ -98,6 +100,16 @@ export class IssueProcessor {
       if (!staleMessage) {
         core.debug(`Skipping ${issueType} due to empty stale message`);
         continue;
+      }
+
+      if (issue.state === 'closed') {
+        core.debug(`Skipping ${issueType} because it is closed`);
+        continue; // don't process closed issues
+      }
+
+      if (issue.locked) {
+        core.debug(`Skipping ${issueType} because it is locked`);
+        continue; // don't process locked issues
       }
 
       if (

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -14,6 +14,20 @@ export interface Issue {
   locked: boolean;
 }
 
+export interface User {
+  type: string;
+}
+
+export interface Comment {
+  user: User;
+}
+
+export interface IssueEvent {
+  created_at: string;
+  event: string;
+  label: Label;
+}
+
 export interface Label {
   name: string;
 }
@@ -30,6 +44,7 @@ export interface IssueProcessorOptions {
   exemptPrLabels: string;
   onlyLabels: string;
   operationsPerRun: number;
+  removeStaleWhenUpdated: boolean;
   debugOnly: boolean;
 }
 
@@ -43,10 +58,16 @@ export class IssueProcessor {
 
   readonly staleIssues: Issue[] = [];
   readonly closedIssues: Issue[] = [];
+  readonly removedLabelIssues: Issue[] = [];
 
   constructor(
     options: IssueProcessorOptions,
-    getIssues?: (page: number) => Promise<Issue[]>
+    getIssues?: (page: number) => Promise<Issue[]>,
+    listIssueComments?: (
+      issueNumber: number,
+      sinceDate: string
+    ) => Promise<Comment[]>,
+    getLabelCreationDate?: (issue: Issue, label: string) => Promise<string>
   ) {
     this.options = options;
     this.operationsLeft = options.operationsPerRun;
@@ -54,6 +75,14 @@ export class IssueProcessor {
 
     if (getIssues) {
       this.getIssues = getIssues;
+    }
+
+    if (listIssueComments) {
+      this.listIssueComments = listIssueComments;
+    }
+
+    if (getLabelCreationDate) {
+      this.getLabelCreationDate = getLabelCreationDate;
     }
 
     if (this.options.debugOnly) {
@@ -123,25 +152,12 @@ export class IssueProcessor {
 
       if (IssueProcessor.isLabeled(issue, staleLabel)) {
         core.debug(`Found a stale ${issueType}`);
-        if (
-          this.options.daysBeforeClose >= 0 &&
-          IssueProcessor.wasLastUpdatedBefore(
-            issue,
-            this.options.daysBeforeClose
-          )
-        ) {
-          core.debug(
-            `Closing ${issueType} because it was last updated on ${issue.updated_at}`
-          );
-          await this.closeIssue(issue);
-          this.operationsLeft -= 1;
-        } else {
-          core.debug(
-            `Ignoring stale ${issueType} because it was updated recenlty`
-          );
-        }
+        await this.processStaleIssue(issue, issueType, staleLabel);
       } else if (
-        IssueProcessor.wasLastUpdatedBefore(issue, this.options.daysBeforeStale)
+        !IssueProcessor.updatedSince(
+          issue.updated_at,
+          this.options.daysBeforeStale
+        )
       ) {
         core.debug(
           `Marking ${issueType} stale because it was last updated on ${issue.updated_at}`
@@ -153,6 +169,87 @@ export class IssueProcessor {
 
     // do the next batch
     return this.processIssues(page + 1);
+  }
+
+  // handle all of the stale issue logic when we find a stale issue
+  private async processStaleIssue(
+    issue: Issue,
+    issueType: string,
+    staleLabel: string
+  ) {
+    if (this.options.daysBeforeClose < 0) {
+      return; // nothing to do because we aren't closing stale issues
+    }
+
+    const markedStaleOn: string = await this.getLabelCreationDate(
+      issue,
+      staleLabel
+    );
+    const issueHasComments: boolean = await this.isIssueStillStale(
+      issue,
+      markedStaleOn
+    );
+
+    const issueHasUpdate: boolean = IssueProcessor.updatedSince(
+      issue.updated_at,
+      this.options.daysBeforeClose
+    );
+
+    core.debug(`Issue #${issue.number} marked stale on: ${markedStaleOn}`);
+    core.debug(`Issue #${issue.number} has been updated: ${issueHasUpdate}`);
+    core.debug(
+      `Issue #${issue.number} has been commented on: ${issueHasComments}`
+    );
+
+    if (!issueHasComments && !issueHasUpdate) {
+      core.debug(
+        `Closing ${issueType} because it was last updated on ${issue.updated_at}`
+      );
+      await this.closeIssue(issue);
+    } else {
+      if (this.options.removeStaleWhenUpdated) {
+        await this.removeLabel(issue, staleLabel);
+      }
+      core.debug(`Ignoring stale ${issueType} because it was updated recenlty`);
+    }
+  }
+
+  // checks to see if a given issue is still stale (has had activity on it)
+  private async isIssueStillStale(
+    issue: Issue,
+    sinceDate: string
+  ): Promise<boolean> {
+    core.debug(
+      `Checking for comments on issue #${issue.number} since ${sinceDate} to see if it is still stale`
+    );
+
+    if (!sinceDate) {
+      return true; // if no date was provided then the issue was marked stale a long time ago
+    }
+
+    this.operationsLeft -= 1;
+
+    // find any comments since the stale label
+    const comments = await this.listIssueComments(issue.number, sinceDate);
+
+    // if there are any user comments returned, issue is not stale anymore
+    return comments.filter(comment => comment.user.type === 'User').length > 0;
+  }
+
+  // grab comments for an issue since a given date
+  private async listIssueComments(
+    issueNumber: number,
+    sinceDate: string
+  ): Promise<Comment[]> {
+    // find any comments since date on the given issue
+    const comments = await this.client.issues.listComments({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      issue_number: issueNumber,
+      since: sinceDate
+    });
+
+    return comments.data;
   }
 
   // grab issues from github in baches of 100
@@ -181,6 +278,8 @@ export class IssueProcessor {
 
     this.staleIssues.push(issue);
 
+    this.operationsLeft -= 2;
+
     if (this.options.debugOnly) {
       return;
     }
@@ -200,13 +299,15 @@ export class IssueProcessor {
     });
   }
 
-  /// Close an issue based on staleness
+  // Close an issue based on staleness
   private async closeIssue(issue: Issue): Promise<void> {
     core.debug(
       `Closing issue #${issue.number} - ${issue.title} for being stale`
     );
 
     this.closedIssues.push(issue);
+
+    this.operationsLeft -= 1;
 
     if (this.options.debugOnly) {
       return;
@@ -220,17 +321,67 @@ export class IssueProcessor {
     });
   }
 
+  // Remove a label from an issue
+  private async removeLabel(issue: Issue, label: string): Promise<void> {
+    core.debug(
+      `Removing label ${label} from issue #${issue.number} - ${issue.title}`
+    );
+
+    this.removedLabelIssues.push(issue);
+
+    this.operationsLeft -= 1;
+
+    if (this.options.debugOnly) {
+      return;
+    }
+
+    await this.client.issues.removeLabel({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      issue_number: issue.number,
+      name: encodeURIComponent(label) // A label can have a "?" in the name
+    });
+  }
+
+  // returns the creation date of a given label on an issue (or nothing if no label existed)
+  ///see https://developer.github.com/v3/activity/events/
+  private async getLabelCreationDate(
+    issue: Issue,
+    label: string
+  ): Promise<string> {
+    core.debug(`Checking for label ${label} on issue #${issue.number}`);
+
+    this.operationsLeft -= 1;
+
+    const options = this.client.issues.listEvents.endpoint.merge({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      per_page: 100,
+      issue_number: issue.number
+    });
+
+    const events: IssueEvent[] = await this.client.paginate(options);
+    const reversedEvents = events.reverse();
+
+    const staleLabeledEvent = reversedEvents.find(
+      event => event.event === 'labeled' && event.label.name === label
+    );
+
+    return staleLabeledEvent!.created_at;
+  }
+
   private static isLabeled(issue: Issue, label: string): boolean {
     const labelComparer: (l: Label) => boolean = l =>
       label.localeCompare(l.name, undefined, {sensitivity: 'accent'}) === 0;
     return issue.labels.filter(labelComparer).length > 0;
   }
 
-  private static wasLastUpdatedBefore(issue: Issue, num_days: number): boolean {
+  private static updatedSince(timestamp: string, num_days: number): boolean {
     const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
     const millisSinceLastUpdated =
-      new Date().getTime() - new Date(issue.updated_at).getTime();
-    return millisSinceLastUpdated >= daysInMillis;
+      new Date().getTime() - new Date(timestamp).getTime();
+
+    return millisSinceLastUpdated < daysInMillis;
   }
 
   private static parseCommaSeparatedString(s: string): string[] {

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import {Octokit} from '@octokit/rest';
 
-type OcotoKitIssueList = Octokit.Response<Octokit.IssuesListForRepoResponse>;
+type OctoKitIssueList = Octokit.Response<Octokit.IssuesListForRepoResponse>;
 
 export interface Issue {
   title: string;
@@ -157,7 +157,7 @@ export class IssueProcessor {
 
   // grab issues from github in baches of 100
   private async getIssues(page: number): Promise<Issue[]> {
-    const issueResult: OcotoKitIssueList = await this.client.issues.listForRepo(
+    const issueResult: OctoKitIssueList = await this.client.issues.listForRepo(
       {
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -254,16 +254,14 @@ export class IssueProcessor {
 
   // grab issues from github in baches of 100
   private async getIssues(page: number): Promise<Issue[]> {
-    const issueResult: OctoKitIssueList = await this.client.issues.listForRepo(
-      {
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        state: 'open',
-        labels: this.options.onlyLabels,
-        per_page: 100,
-        page
-      }
-    );
+    const issueResult: OctoKitIssueList = await this.client.issues.listForRepo({
+      owner: github.context.repo.owner,
+      repo: github.context.repo.repo,
+      state: 'open',
+      labels: this.options.onlyLabels,
+      per_page: 100,
+      page
+    });
 
     return issueResult.data;
   }

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -67,7 +67,7 @@ export class IssueProcessor {
       issueNumber: number,
       sinceDate: string
     ) => Promise<Comment[]>,
-    getLabelCreationDate?: (issue: Issue, label: string) => Promise<string>
+    getLabelCreationDate?: (issue: Issue, label: string) => Promise<string | undefined>
   ) {
     this.options = options;
     this.operationsLeft = options.operationsPerRun;
@@ -190,25 +190,27 @@ export class IssueProcessor {
       return; // nothing to do because we aren't closing stale issues
     }
 
-    const markedStaleOn: string = await this.getLabelCreationDate(
+    const markedStaleOn: string | undefined = await this.getLabelCreationDate(
       issue,
       staleLabel
     );
     const issueHasComments: boolean = await this.isIssueStillStale(
       issue,
-      markedStaleOn
+      markedStaleOn || issue.updated_at
     );
-
     const issueHasUpdate: boolean = IssueProcessor.updatedSince(
       issue.updated_at,
       this.options.daysBeforeClose
     );
 
-    core.debug(`Issue #${issue.number} marked stale on: ${markedStaleOn}`);
+    if (markedStaleOn) {
+      core.debug(`Issue #${issue.number} marked stale on: ${markedStaleOn}`);
+    }
+    else {
+      core.debug(`Issue #${issue.number} is not marked stale, but last update of ${issue.updated_at} is older than ${this.options.daysBeforeStale} days`);
+    }
     core.debug(`Issue #${issue.number} has been updated: ${issueHasUpdate}`);
-    core.debug(
-      `Issue #${issue.number} has been commented on: ${issueHasComments}`
-    );
+    core.debug(`Issue #${issue.number} has been commented on: ${issueHasComments}`);
 
     if (!issueHasComments && !issueHasUpdate) {
       core.debug(
@@ -219,7 +221,7 @@ export class IssueProcessor {
       if (this.options.removeStaleWhenUpdated) {
         await this.removeLabel(issue, staleLabel);
       }
-      core.debug(`Ignoring stale ${issueType} because it was updated recenlty`);
+      core.debug(`Ignoring stale ${issueType} because it was updated recently`);
     }
   }
 
@@ -355,7 +357,7 @@ export class IssueProcessor {
   private async getLabelCreationDate(
     issue: Issue,
     label: string
-  ): Promise<string> {
+  ): Promise<string | undefined> {
     core.debug(`Checking for label ${label} on issue #${issue.number}`);
 
     this.operationsLeft -= 1;
@@ -374,7 +376,12 @@ export class IssueProcessor {
       event => event.event === 'labeled' && event.label.name === label
     );
 
-    return staleLabeledEvent!.created_at;
+    if (!staleLabeledEvent) {
+      // Must be old rather than labeled
+      return undefined;
+    }
+
+    return staleLabeledEvent.created_at;
   }
 
   private static isLabeled(issue: Issue, label: string): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,9 @@ function getAndValidateArgs(): IssueProcessorOptions {
     operationsPerRun: parseInt(
       core.getInput('operations-per-run', {required: true})
     ),
+    removeStaleWhenUpdated: !(
+      core.getInput('remove-stale-when-updated') === 'false'
+    ),
     debugOnly: core.getInput('debug-only') === 'true'
   };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    //"sourceMap": true
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
👋  Hi All,

We needed the ability to add a comment to the issues once the stale bot closed them so our customers had a better idea of why it was closed and what the next steps they needed to take to action their item.  


Here is what we added:

* Added `close-pr-message` and `close-issue-message` to get closing message
* Changed the close logic so that ancient issues won't immediately close if they are past the both the stale and close date
* Added a mocking library so we can test the octokit calls without needing to actually talk to the api
* Think we ran eslint and prettier because I see a lot of formatting changes 😐 


I am happy to talk about if you'd like any or all of this.  I'll just have to figure out how to break apart the pieces youd like if so 😄 

cc: @froi @zkoppert @jasonmacgowan