### PR TITLE
Update hint for how to pass in the GitHub token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Close issues and pull requests with no recent activity'
 author: 'GitHub'
 inputs:
   repo-token:
-    description: 'Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`.'
+    description: 'Token for the repository. Can be passed in using `${{ secrets.GITHUB_TOKEN }}`.'
     required: true
   stale-issue-message:
     description: 'The message to post on the issue when tagging it. If none provided, will not mark issues stale.'


### PR DESCRIPTION
This change updates the comment about how to inject the GitHub token. I'm new to passing in secrets and didn't understand I needed to prefix the curlies with a `$`.