### PR TITLE
Avoid changing default options in tests

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -31,7 +31,7 @@ function generateIssue(
   };
 }
 
-const DefaultProcessorOptions: IssueProcessorOptions = {
+const DefaultProcessorOptions: IssueProcessorOptions = Object.freeze({
   repoToken: 'none',
   staleIssueMessage: 'This issue is stale',
   stalePrMessage: 'This PR is stale',
@@ -46,7 +46,7 @@ const DefaultProcessorOptions: IssueProcessorOptions = {
   debugOnly: true,
   removeStaleWhenUpdated: false,
   ascending: false
-};
+});
 
 test('empty issue list results in 1 operation', async () => {
   const processor = new IssueProcessor(
@@ -515,7 +515,7 @@ test('stale label should be removed if a comment was added to a stale issue', as
     )
   ];
 
-  const opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.removeStaleWhenUpdated = true;
 
   const processor = new IssueProcessor(
@@ -545,7 +545,7 @@ test('stale label should not be removed if a comment was added by the bot (and t
     )
   ];
 
-  const opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.removeStaleWhenUpdated = true;
 
   const processor = new IssueProcessor(
@@ -575,7 +575,7 @@ test('stale issues should not be closed until after the closed number of days', 
     )
   ];
 
-  const opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.daysBeforeStale = 5; // stale after 5 days
   opts.daysBeforeClose = 1; // closes after 6 days
 
@@ -607,7 +607,7 @@ test('stale issues should be closed if the closed nubmer of days (additive) is a
     )
   ];
 
-  const opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.daysBeforeStale = 5; // stale after 5 days
   opts.daysBeforeClose = 1; // closes after 6 days
 
@@ -638,7 +638,7 @@ test('stale issues should not be closed until after the closed number of days (l
     )
   ];
 
-  const opts = DefaultProcessorOptions;
+  const opts = {...DefaultProcessorOptions};
   opts.daysBeforeStale = 5; // stale after 5 days
   opts.daysBeforeClose = 20; // closes after 25 days
 


### PR DESCRIPTION
Primarily because changing the default options shared amongst tests will affect other tests.

Therefore freezing the default options object so it cannot be changed directly, and making sure all tests *copy* the default options before making changes to the resulting object.