### PR TITLE
Allow for issues/PRs to be closed after manually being marked as stale

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -107,6 +107,31 @@ test('processing an issue with no label will make it stale and not close it if d
   expect(processor.closedIssues.length).toEqual(0);
 });
 
+test('processing an issue with no label will not make it stale if days-before-stale is set to -1', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'An issue with no label', '2020-01-01T17:00:00Z')
+  ];
+
+  const opts = {
+    ...DefaultProcessorOptions,
+    staleIssueMessage: '',
+    daysBeforeStale: -1
+  };
+
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(0);
+});
+
 test('processing an issue with no label will make it stale but not close it', async () => {
   // issue should be from 2 days ago so it will be
   // stale but not close-able, based on default settings
@@ -169,6 +194,60 @@ test('processing a stale PR will close it', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(1);
+});
+
+test('processing a stale issue will close it even if configured not to mark as stale', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'An issue with no label', '2020-01-01T17:00:00Z', false, [
+      'Stale'
+    ])
+  ];
+
+  const opts = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: -1,
+    staleIssueMessage: ''
+  };
+
+  const processor = new IssueProcessor(
+    opts,
+    async p => (p == 1 ? TestIssueList : []),
+    async (num, dt) => [],
+    async (issue, label) => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues.length).toEqual(0);
+  expect(processor.closedIssues.length).toEqual(1);
+});
+
+test('processing a stale PR will close it even if configured not to mark as stale', async () => {
+  const TestIssueList: Issue[] = [
+    generateIssue(1, 'An issue with no label', '2020-01-01T17:00:00Z', true, [
+      'Stale'
+    ])
+  ];
+
+  const opts = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: -1,
+    stalePrMessage: ''
+  };
+
+  const processor = new IssueProcessor(
+    opts,
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   stale-pr-message:
     description: 'The message to post on the pr when tagging it. If none provided, will not mark pull requests stale.'
   days-before-stale:
-    description: 'The number of days old an issue can be before marking it stale.'
+    description: 'The number of days old an issue can be before marking it stale. Set to -1 to never mark issues or pull requests as stale automatically.'
     default: 60
   days-before-close:
     description: 'The number of days to wait to close an issue or pull request after it being marked stale. Set to -1 to never close stale issues.'

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -125,8 +125,9 @@ export class IssueProcessor {
         isPr ? this.options.exemptPrLabels : this.options.exemptIssueLabels
       );
       const issueType: string = isPr ? 'pr' : 'issue';
+      const shouldMarkWhenStale = this.options.daysBeforeStale > -1;
 
-      if (!staleMessage) {
+      if (!staleMessage && shouldMarkWhenStale) {
         core.info(`Skipping ${issueType} due to empty stale message`);
         continue;
       }
@@ -160,7 +161,7 @@ export class IssueProcessor {
       );
 
       // determine if this issue needs to be marked stale first
-      if (!isStale && shouldBeStale) {
+      if (!isStale && shouldBeStale && shouldMarkWhenStale) {
         core.info(
           `Marking ${issueType} stale because it was last updated on ${issue.updated_at} and it does not have a stale label`
         );


### PR DESCRIPTION
Previously this action would stop and skip all issues or pull requests it found if no `stale-issue-message | stale-pr-message` option had been configured.

In practise that meant this action could not be used in repositories where the maintainers would want to manually mark issues and pull requests as stale, instead of this action being responsible for the said marking.

That's what these changes allows for, maintainers being responsible for marking, but still want help from this action to close those issues or pull requests X days after they got manually marked as stale by labelling them.

Configuring `days-before-stale: -1` will activate that behaviour, inspired by how `days-before-close: -1` works already.

Would that sound like a good fit for this action by any chance?