### PR TITLE
feat: Add `delete-branch` option to delete PR branches after closing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,9 @@ inputs:
   skip-stale-issue-message:
     description: 'Skip adding stale message when marking an issue as stale.'
     default: false
+  delete-branch:
+    description: 'Delete the git branch after closing a stale pull request.'
+    default: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -495,7 +495,7 @@ export class IssueProcessor {
       await this.client.git.deleteRef({
         owner: context.repo.owner,
         repo: context.repo.repo,
-        ref: branch
+        ref: `heads/${branch}`
       });
     } catch (error) {
       core.error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,8 @@ function getAndValidateArgs(): IssueProcessorOptions {
     debugOnly: core.getInput('debug-only') === 'true',
     ascending: core.getInput('ascending') === 'true',
     skipStalePrMessage: core.getInput('skip-stale-pr-message') === 'true',
-    skipStaleIssueMessage: core.getInput('skip-stale-issue-message') === 'true'
+    skipStaleIssueMessage: core.getInput('skip-stale-issue-message') === 'true',
+    deleteBranch: core.getInput('delete-branch') === 'true'
   };
 
   for (const numberInput of [


### PR DESCRIPTION
Closes #57 

## Testing
1. Setup PR which has `delete-branch` enabled https://github.com/alexbrazier/stale/pull/2
2. Verified it closed and deleted the test PR https://github.com/alexbrazier/stale/pull/1

<img width="909" alt="image" src="https://user-images.githubusercontent.com/5689874/95510450-d60b7780-09ad-11eb-808a-5ca765482ead.png">

<img width="547" alt="image" src="https://user-images.githubusercontent.com/5689874/95510524-f804fa00-09ad-11eb-9cd5-c4237fcc5432.png">
