### PR TITLE
Stop filtering comments by `github.context.actor` when determining if an issue is still stale

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -171,7 +171,7 @@ class IssueProcessor {
             }
             // find any comments since the date
             const comments = yield this.listIssueComments(issue.number, sinceDate);
-            const filteredComments = comments.filter(comment => comment.user.type === 'User' && comment.user.login !== github_1.context.actor);
+            const filteredComments = comments.filter(comment => comment.user.type === 'User');
             core.info(`Comments not made by ${github_1.context.actor} or another bot: ${filteredComments.length}`);
             // if there are any user comments returned
             return filteredComments.length > 0;

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -272,8 +272,7 @@ export class IssueProcessor {
     const comments = await this.listIssueComments(issue.number, sinceDate);
 
     const filteredComments = comments.filter(
-      comment =>
-        comment.user.type === 'User' && comment.user.login !== context.actor
+      comment => comment.user.type === 'User'
     );
 
     core.info(


### PR DESCRIPTION
As originally mentioned in https://github.com/actions/stale/pull/73#discussion_r498578074, I added a scheduled workflow with the stale action and it seems that when the action runs, `github.context.actor` is myself, not the github actions bot. As a result, an issue that I had commented on after it was labeled `stale` ended up getting closed anyway. Here's what's in the logs for the action (incorrectly claiming that I am a bot):
```
Checking for comments on issue #15419 since 2020-09-22T00:06:03Z
Comments not made by rmacklin or another bot: 0
```

It seems like others have run into the same issue: https://github.com/actions/stale/issues/21#issuecomment-656002085.

According to this post in the GitHub Support Community, it seems to be expected behavior that the actor will be the user who set up the schedule:
https://github.community/t/who-will-be-the-github-actor-when-a-workflow-runs-on-a-schedule/17369

Thus, it doesn't seem appropriate to ignore comments from `github.context.actor` when determining if there has been activity since the issue was labeled stale; that is not a bot user as previously thought when this behavior was originally added in 96b682d29f2b26168a8b283c62da1ad3f1262120. So in this PR I'm proposing we stop filtering out those comments.