### PR TITLE
Implement issue/pr only labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ $ npm test
 | `exempt-issue-labels` | Labels on an issue exempted from being marked as stale. | Optional
 | `exempt-pr-labels` | Labels on the pr exempted from being marked as stale. | Optional
 | `only-labels` | Only labels checked for stale issue/pr. | Optional
+| `only-issue-labels` | Only labels checked for stale issue. | Optional
+| `only-pr-labels` | Only labels checked for pr. | Optional
 | `operations-per-run` | Maximum number of operations per run. *Defaults to **30*** | Optional
 | `remove-stale-when-updated` | Remove stale label from issue/pr on updates or comments. *Defaults to **true*** | Optional
 | `debug-only` | Dry-run on action. *Defaults to **false*** | Optional

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -46,6 +46,8 @@ const DefaultProcessorOptions: IssueProcessorOptions = Object.freeze({
   closePrLabel: '',
   exemptPrLabels: '',
   onlyLabels: '',
+  onlyIssueLabels: '',
+  onlyPrLabels: '',
   operationsPerRun: 100,
   debugOnly: true,
   removeStaleWhenUpdated: false,

--- a/dist/index.js
+++ b/dist/index.js
@@ -90,6 +90,7 @@ class IssueProcessor {
                     ? this.options.closePrLabel
                     : this.options.closeIssueLabel;
                 const exemptLabels = IssueProcessor.parseCommaSeparatedString(isPr ? this.options.exemptPrLabels : this.options.exemptIssueLabels);
+                const onlyLabels = IssueProcessor.parseCommaSeparatedString(isPr ? this.options.onlyPrLabels : this.options.onlyIssueLabels);
                 const skipMessage = isPr
                     ? this.options.skipStalePrMessage
                     : this.options.skipStaleIssueMessage;
@@ -110,6 +111,10 @@ class IssueProcessor {
                 if (exemptLabels.some((exemptLabel) => IssueProcessor.isLabeled(issue, exemptLabel))) {
                     core.info(`Skipping ${issueType} because it has an exempt label`);
                     continue; // don't process exempt issues
+                }
+                if (onlyLabels.length > 0 &&
+                    !onlyLabels.some((onlyLabel) => IssueProcessor.isLabeled(issue, onlyLabel))) {
+                    core.info(`Skipping ${issueType} because it doesn't have any of the mandatory labels`);
                 }
                 // does this issue have a stale label?
                 let isStale = IssueProcessor.isLabeled(issue, staleLabel);
@@ -437,6 +442,8 @@ function getAndValidateArgs() {
         closePrLabel: core.getInput('close-pr-label'),
         exemptPrLabels: core.getInput('exempt-pr-labels'),
         onlyLabels: core.getInput('only-labels'),
+        onlyIssueLabels: core.getInput('only-issue-labels'),
+        onlyPrLabels: core.getInput('only-issue-labels'),
         operationsPerRun: parseInt(core.getInput('operations-per-run', { required: true })),
         removeStaleWhenUpdated: !(core.getInput('remove-stale-when-updated') === 'false'),
         debugOnly: core.getInput('debug-only') === 'true',

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -46,6 +46,8 @@ export interface IssueProcessorOptions {
   closePrLabel: string;
   exemptPrLabels: string;
   onlyLabels: string;
+  onlyIssueLabels: string,
+  onlyPrLabels: string,
   operationsPerRun: number;
   removeStaleWhenUpdated: boolean;
   debugOnly: boolean;
@@ -134,6 +136,9 @@ export class IssueProcessor {
       const exemptLabels = IssueProcessor.parseCommaSeparatedString(
         isPr ? this.options.exemptPrLabels : this.options.exemptIssueLabels
       );
+      const onlyLabels = IssueProcessor.parseCommaSeparatedString(
+        isPr ? this.options.onlyPrLabels : this.options.onlyIssueLabels
+      );
       const skipMessage = isPr
         ? this.options.skipStalePrMessage
         : this.options.skipStaleIssueMessage;
@@ -162,6 +167,14 @@ export class IssueProcessor {
       ) {
         core.info(`Skipping ${issueType} because it has an exempt label`);
         continue; // don't process exempt issues
+      }
+
+      if (onlyLabels.length > 0 &&
+        !onlyLabels.some((onlyLabel: string) =>
+          IssueProcessor.isLabeled(issue, onlyLabel)
+        )
+      ) {
+        core.info(`Skipping ${issueType} because it doesn't have any of the mandatory labels`)
       }
 
       // does this issue have a stale label?

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,8 @@ function getAndValidateArgs(): IssueProcessorOptions {
     closePrLabel: core.getInput('close-pr-label'),
     exemptPrLabels: core.getInput('exempt-pr-labels'),
     onlyLabels: core.getInput('only-labels'),
+    onlyIssueLabels: core.getInput('only-issue-labels'),
+    onlyPrLabels: core.getInput('only-issue-labels'),
     operationsPerRun: parseInt(
       core.getInput('operations-per-run', {required: true})
     ),


### PR DESCRIPTION
Hi,

I would like to be able to filter issues/prs with different labels, i.e. being
able to only mark issues that have a label X and PRs that do not have a label as
stale. This PR implements just that.

Let me know if the idea/implementation looks alright to you and I'll write
tests :).
