### PR TITLE
receive all issues past stale date

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -201,6 +201,8 @@ class IssueProcessor {
         return __awaiter(this, void 0, void 0, function* () {
             // generate type for response
             const endpoint = this.client.issues.listForRepo;
+            const today = new Date();
+            const timeSince = new Date(new Date().setDate(today.getDate() - this.options.daysBeforeStale));
             try {
                 const issueResult = yield this.client.issues.listForRepo({
                     owner: github_1.context.repo.owner,
@@ -209,6 +211,7 @@ class IssueProcessor {
                     labels: this.options.onlyLabels,
                     per_page: 100,
                     direction: this.options.ascending ? 'asc' : 'desc',
+                    since: timeSince,
                     page
                 });
                 return issueResult.data;

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -309,6 +309,8 @@ export class IssueProcessor {
     // generate type for response
     const endpoint = this.client.issues.listForRepo;
     type OctoKitIssueList = GetResponseTypeFromEndpointMethod<typeof endpoint>;
+    const today: Date = new Date();
+    const timeSince: Date = new Date(new Date().setDate(today.getDate()-this.options.daysBeforeStale));
 
     try {
       const issueResult: OctoKitIssueList = await this.client.issues.listForRepo(
@@ -319,6 +321,7 @@ export class IssueProcessor {
           labels: this.options.onlyLabels,
           per_page: 100,
           direction: this.options.ascending ? 'asc' : 'desc',
+          since: timeSince.toString(),
           page
         }
       );


### PR DESCRIPTION
The stale issue bot currently filters through **all** issues, including issues recently opened that are newer than the number of days before it's marked as stale, wasting several operations. Instead of filtering through these results, we can skip ahead to the issues that are ready to be marked as stale.

Resolves issues like #216 where given a large number of issues and PRs in the queue, no issues or PRs will ever close.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>