### PR TITLE
Determine actor from PAT if possible

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -57,6 +57,7 @@ const DefaultProcessorOptions: IssueProcessorOptions = Object.freeze({
 test('empty issue list results in 1 operation', async () => {
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async () => [],
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -79,6 +80,7 @@ test('processing an issue with no label will make it stale and close it, if it i
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -101,6 +103,7 @@ test('processing an issue with no label will make it stale and not close it if d
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -126,6 +129,7 @@ test('processing an issue with no label will not make it stale if days-before-st
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -150,6 +154,7 @@ test('processing an issue with no label will make it stale but not close it', as
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -175,6 +180,7 @@ test('processing a stale issue will close it', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -200,6 +206,7 @@ test('processing a stale PR will close it', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -227,6 +234,7 @@ test('processing a stale issue will close it even if configured not to mark as s
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -254,6 +262,7 @@ test('processing a stale PR will close it even if configured not to mark as stal
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -280,6 +289,7 @@ test('closed issues will not be marked stale', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => []
   );
@@ -305,6 +315,7 @@ test('stale closed issues will not be closed', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -331,6 +342,7 @@ test('closed prs will not be marked stale', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -357,6 +369,7 @@ test('stale closed prs will not be closed', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -382,8 +395,10 @@ test('locked issues will not be marked stale', async () => {
     )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async () => 'abot',
+    async p => p == 1 ? TestIssueList : []
   );
 
   // process our fake issue list
@@ -408,6 +423,7 @@ test('stale locked issues will not be closed', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -433,8 +449,10 @@ test('locked prs will not be marked stale', async () => {
     )
   ];
 
-  const processor = new IssueProcessor(DefaultProcessorOptions, async p =>
-    p == 1 ? TestIssueList : []
+  const processor = new IssueProcessor(
+    DefaultProcessorOptions,
+    async () => 'abot',
+    async p => p == 1 ? TestIssueList : []
   );
 
   // process our fake issue list
@@ -459,6 +477,7 @@ test('stale locked prs will not be closed', async () => {
 
   const processor = new IssueProcessor(
     DefaultProcessorOptions,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -483,6 +502,7 @@ test('exempt issue labels will not be marked stale', async () => {
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -505,6 +525,7 @@ test('exempt issue labels will not be marked stale (multi issue label with space
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -527,6 +548,7 @@ test('exempt issue labels will not be marked stale (multi issue label)', async (
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -552,6 +574,7 @@ test('exempt pr labels will not be marked stale', async () => {
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -577,6 +600,7 @@ test('stale issues should not be closed if days is set to -1', async () => {
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -605,6 +629,7 @@ test('stale label should be removed if a comment was added to a stale issue', as
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [{user: {login: 'notme', type: 'User'}}], // return a fake comment to indicate there was an update
     async (issue, label) => new Date().toDateString()
@@ -635,6 +660,7 @@ test('stale label should not be removed if a comment was added by the bot (and t
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [{user: {login: 'abot', type: 'User'}}], // return a fake comment to indicate there was an update by the bot
     async (issue, label) => new Date().toDateString()
@@ -666,6 +692,7 @@ test('stale issues should not be closed until after the closed number of days', 
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -698,6 +725,7 @@ test('stale issues should be closed if the closed nubmer of days (additive) is a
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -729,6 +757,7 @@ test('stale issues should not be closed until after the closed number of days (l
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -761,6 +790,7 @@ test('skips stale message on issues when skip-stale-issue-message is set', async
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -805,6 +835,7 @@ test('skips stale message on prs when skip-stale-pr-message is set', async () =>
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -850,6 +881,7 @@ test('not providing state takes precedence over skipStaleIssueMessage', async ()
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()
@@ -883,6 +915,7 @@ test('not providing stalePrMessage takes precedence over skipStalePrMessage', as
 
   const processor = new IssueProcessor(
     opts,
+    async () => 'abot',
     async p => (p == 1 ? TestIssueList : []),
     async (num, dt) => [],
     async (issue, label) => new Date().toDateString()


### PR DESCRIPTION
Hi there, [Homebrew](https://github.com/Homebrew/brew) maintainer here. We were recently in the market for a new way to monitor stale issues (our existing configuration stopped working) and figured that this was a great solution. So far, we've only had one minor hiccup that I have aimed to fix in this PR.

This has been reported a few times before, but our issue revolves around the fact that the stale action checks for comments that are not made by a bot or `context.actor` (which is the user who most recently modified the workflow). I am aware of one attempt at removing this in https://github.com/actions/stale/pull/192. The [response](https://github.com/actions/stale/pull/192#issuecomment-731124617) given in that PR makes sense to me:

> The user who set up the schedule will be the "bot". In most cases this is desired, since the bot user will add issue labels and other comments on stale and we don't want those to count, even if it introduces the problem of excluding the created user.

This seems reasonable for smaller projects, but larger projects (like Homebrew) tend to have their own "bot user" that differs from the one who set up the workflow. In our specific case, I set up the stale workflow which made me the "actor". However, the `repo-token` we provide is for @BrewTestBot not for my user. That means that any actions taken are on the behalf of @BrewTestBot. Actions that I take should be treated no differently than those made by another user.

---

This PR attempts to fix this by trying to determine who the "actor" should be based on the `repo-token`. This will now run [`octokit.users.getAuthenticated();`](https://octokit.github.io/rest.js/v16#users-get-authenticated) and, if successful, will set the "actor" by accessing `.data.login`. If the API call fails, it will default back to `context.actor` as is currently done.

One potential thing to note is that it seems that using the default `${{ secrets.GITHUB_TOKEN }}` does not have the appropriate permissions to run the API call. However, a PAT with no additional permissions does seem to have the appropriate scope to run the call. While this is not ideal, it is no worse than the current implementation because it will still fall back on `context.actor`. I would gladly accept any ideas about how to get around this limitation.

---

I think this is a reasonable compromise, but if it's not in the desired direction, I would, instead, propose adding a new option to the workflow to set an e.g. `ignored-users` option to the login of any users whose comments should be ignored when determining if new comments should "un-stale" an issue. This could default to `context.actor`. That way, projects like Homebrew can specify `ignored-users: BrewTestBot` and not worry about the `context.actor` issue.
