### PR TITLE
Only have issues being closed or marked as stale count as operations

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -65,8 +65,8 @@ test('empty issue list results in 1 operation', async () => {
   // process our fake issue list
   const operationsLeft = await processor.processIssues(1);
 
-  // processing an empty issue list should result in 1 operation
-  expect(operationsLeft).toEqual(99);
+  // processing an empty issue list should result in 0 operations
+  expect(operationsLeft).toEqual(100);
 });
 
 test('processing an issue with no label will make it stale and close it, if it is old enough only if days-before-close is set to 0', async () => {

--- a/src/IssueProcessor.ts
+++ b/src/IssueProcessor.ts
@@ -106,7 +106,6 @@ export class IssueProcessor {
   async processIssues(page = 1): Promise<number> {
     // get the next batch of issues
     const issues: Issue[] = await this.getIssues(page);
-    this.operationsLeft -= 1;
 
     if (issues.length <= 0) {
       core.info('No more issues found to process. Exiting.');
@@ -306,7 +305,7 @@ export class IssueProcessor {
     }
   }
 
-  // grab issues from github in baches of 100
+  // grab issues from github in batches of 100
   private async getIssues(page: number): Promise<Issue[]> {
     // generate type for response
     const endpoint = this.client.issues.listForRepo;
@@ -342,7 +341,7 @@ export class IssueProcessor {
 
     this.staleIssues.push(issue);
 
-    this.operationsLeft -= 2;
+    this.operationsLeft -= 1;
 
     // if the issue is being marked stale, the updated date should be changed to right now
     // so that close calculations work correctly
@@ -438,8 +437,6 @@ export class IssueProcessor {
 
     this.removedLabelIssues.push(issue);
 
-    this.operationsLeft -= 1;
-
     if (this.options.debugOnly) {
       return;
     }
@@ -463,8 +460,6 @@ export class IssueProcessor {
     label: string
   ): Promise<string | undefined> {
     core.info(`Checking for label on issue #${issue.number}`);
-
-    this.operationsLeft -= 1;
 
     const options = this.client.issues.listEvents.endpoint.merge({
       owner: context.repo.owner,


### PR DESCRIPTION
The aim of this PR is to use what I think is a better UX for what "operations per run" means

Currently it's not immediately obvious what counts as an operation unless you go diving into the code, these changes make it so that only either an issue being marked as stale or being closed counts as an operation which simplifies things and makes it easier to rate limit how many issues are affected in a particular run

I'm happy to discuss this though if there are any other ideas out there but this has been a point of frustration for me