### PR TITLE
Typo in how to perform check for specific labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ jobs:
           exempt-all-pr-milestones: true
 ```
 
-Avoid stale for specific labels:
+Check stale for specific labels:
 
 ```yaml
 name: 'Close stale issues and PRs'


### PR DESCRIPTION
Not tested but feels like a typo?

Or if we keep the title it `exempt` feels more approriate:

          exempt-issue-labels: 'roadmap'
          exempt-pr-labels: 'roadmap'