### PR TITLE
feat(remove-stale-when-updated): Split remove-stale-when-updated option into remove-stale-when-updated and remove-stale-when-commented

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Every argument is optional.
 | `only-pr-labels`              | Only PRs with ALL these labels are checked.<br>Separate multiple labels with commas (eg. "question,answered").<br>_Override `only-labels`_.    |
 | `any-of-labels`               | Only issues and PRs with ANY of these labels are checked.<br>Separate multiple labels with commas (eg. "incomplete,waiting-feedback").         |
 | `operations-per-run`          | Maximum number of operations per run.<br>GitHub API CRUD related.<br>_Defaults to **30**_.                                                     |
-| `remove-stale-when-updated`   | Remove stale label from issue/PR on updates or comments.<br>_Defaults to **true**_.                                                            |
+| `remove-stale-when-commented` | Remove stale label from issue/PR on comments.<br>_Defaults to **true**_.                                                                       |
+| `remove-stale-when-updated`   | Remove stale label from issue/PR on any update, including comments.<br>_Defaults to **true**_.                                                 |
 | `debug-only`                  | Dry-run on action.<br>_Defaults to **false**_.                                                                                                 |
 | `ascending`                   | Order to get issues/PR.<br>`true` is ascending, `false` is descending.<br>_Defaults to **false**_.                                             |
 | `skip-stale-issue-message`    | Skip adding stale message on stale issue.<br>_Defaults to **false**_.                                                                          |

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -24,6 +24,7 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   anyOfLabels: '',
   operationsPerRun: 100,
   debugOnly: true,
+  removeStaleWhenCommented: false,
   removeStaleWhenUpdated: false,
   ascending: false,
   skipStaleIssueMessage: false,

--- a/dist/index.js
+++ b/dist/index.js
@@ -512,7 +512,8 @@ class IssuesProcessor {
             const issueHasUpdate = IssuesProcessor._updatedSince(issue.updated_at, daysBeforeClose);
             issueLogger.info(`$$type has been updated: ${issueHasUpdate}`);
             // should we un-stale this issue?
-            if (this.options.removeStaleWhenUpdated && issueHasComments) {
+            if ((this.options.removeStaleWhenCommented && issueHasComments) ||
+                (this.options.removeStaleWhenUpdated && issueHasUpdate)) {
                 yield this._removeStaleLabel(issue, staleLabel);
             }
             // now start closing logic
@@ -1547,6 +1548,7 @@ function _getAndValidateArgs() {
         onlyPrLabels: core.getInput('only-pr-labels'),
         anyOfLabels: core.getInput('any-of-labels'),
         operationsPerRun: parseInt(core.getInput('operations-per-run', { required: true })),
+        removeStaleWhenCommented: !(core.getInput('remove-stale-when-commented') === 'false'),
         removeStaleWhenUpdated: !(core.getInput('remove-stale-when-updated') === 'false'),
         debugOnly: core.getInput('debug-only') === 'true',
         ascending: core.getInput('ascending') === 'true',

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -32,6 +32,7 @@ describe('Issue', (): void => {
       onlyPrLabels: '',
       anyOfLabels: '',
       operationsPerRun: 0,
+      removeStaleWhenCommented: false,
       removeStaleWhenUpdated: false,
       repoToken: '',
       skipStaleIssueMessage: false,

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -444,7 +444,10 @@ export class IssuesProcessor {
     issueLogger.info(`$$type has been updated: ${issueHasUpdate}`);
 
     // should we un-stale this issue?
-    if (this.options.removeStaleWhenUpdated && issueHasComments) {
+    if (
+      (this.options.removeStaleWhenCommented && issueHasComments) ||
+      (this.options.removeStaleWhenUpdated && issueHasUpdate)
+    ) {
       await this._removeStaleLabel(issue, staleLabel);
     }
 

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -23,6 +23,7 @@ export interface IIssuesProcessorOptions {
   onlyPrLabels: string;
   anyOfLabels: string;
   operationsPerRun: number;
+  removeStaleWhenCommented: boolean;
   removeStaleWhenUpdated: boolean;
   debugOnly: boolean;
   ascending: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,9 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     operationsPerRun: parseInt(
       core.getInput('operations-per-run', {required: true})
     ),
+    removeStaleWhenCommented: !(
+      core.getInput('remove-stale-when-commented') === 'false'
+    ),
     removeStaleWhenUpdated: !(
       core.getInput('remove-stale-when-updated') === 'false'
     ),


### PR DESCRIPTION
Currently, although updated PRs are not closed when updated, the stale label is not removed, even after re-running the action:
<img width="942" alt="updated-pr-still-stale" src="https://user-images.githubusercontent.com/3876970/111218788-93c61200-85ad-11eb-9d10-cdb35e11cc4e.png">
(redacted because this is not my PR)

~This PR also removes the label when the PR is updated (for example by pushing a new commit).~

This PR splits the options to remove the stale by renaming `remove-stale-when-updated` to `remove-stale-when-commented` and introducing a new meaning to `remove-stale-when-updated`, which is to remove the stale label when the stale issue is updated in other ways than comments (typically pushing a new commit).

This also happens to fix (what I think is) a bug that was reported to me today: if an issue has a stale label and then updated without comments, the stale timer isn't reset and the issue is still closed after `days-before-close`, not `days-before-stale + days-before-close` as expected.