### PR TITLE
Add support for adding & removing labels when no longer stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Every argument is optional.
 | [remove-stale-when-updated](#remove-stale-when-updated)             | Remove stale label from issues/PRs on updates/comments                   | `true`                |
 | [remove-issue-stale-when-updated](#remove-issue-stale-when-updated) | Remove stale label from issues on updates/comments                       |                       |
 | [remove-pr-stale-when-updated](#remove-pr-stale-when-updated)       | Remove stale label from PRs on updates/comments                          |                       |
-| [labels-to-add-when-updated](#labels-to-add-when-unstale)           | Add specified labels from issue/PR when they become unstale              |                       |
-| [labels-to-remove-when-updated](#labels-to-remove-when-unstale)     | Remove specified labels from issue/PR when they become unstale           |                       |
+| [labels-to-add-when-unstale](#labels-to-add-when-unstale)           | Add specified labels from issue/PR when they become unstale              |                       |
+| [labels-to-remove-when-unstale](#labels-to-remove-when-unstale)     | Remove specified labels from issue/PR when they become unstale           |                       |
 | [debug-only](#debug-only)                                           | Dry-run                                                                  | `false`               |
 | [ascending](#ascending)                                             | Order to get issues/PRs                                                  | `false`               |
 | [start-date](#start-date)                                           | Skip stale action for issues/PRs created before it                       |                       |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Every argument is optional.
 | [remove-stale-when-updated](#remove-stale-when-updated)             | Remove stale label from issues/PRs on updates/comments                   | `true`                |
 | [remove-issue-stale-when-updated](#remove-issue-stale-when-updated) | Remove stale label from issues on updates/comments                       |                       |
 | [remove-pr-stale-when-updated](#remove-pr-stale-when-updated)       | Remove stale label from PRs on updates/comments                          |                       |
+| [labels-to-add-when-updated](#labels-to-add-when-unstale)           | Add specified labels from issue/PR when they become unstale              |                       |
+| [labels-to-remove-when-updated](#labels-to-remove-when-unstale)     | Remove specified labels from issue/PR when they become unstale           |                       |
 | [debug-only](#debug-only)                                           | Dry-run                                                                  | `false`               |
 | [ascending](#ascending)                                             | Order to get issues/PRs                                                  | `false`               |
 | [start-date](#start-date)                                           | Skip stale action for issues/PRs created before it                       |                       |
@@ -304,6 +306,20 @@ Default value: unset
 #### remove-pr-stale-when-updated
 
 Override [remove-stale-when-updated](#remove-stale-when-updated) but only to automatically remove the stale label when the pull requests are updated (based on [GitHub issue](https://docs.github.com/en/rest/reference/issues) field `updated_at`) or commented.
+
+Default value: unset
+
+#### labels-to-add-when-unstale
+
+A comma delimited list of labels to add when a stale issue receives activity and has the [stale-issue-label](#stale-issue-label) or [stale-pr-label](#stale-pr-label) removed from it.
+
+Default value: unset
+
+#### labels-to-remove-when-unstale
+
+A comma delimited list of labels to remove when a stale issue receives activity and has the [stale-issue-label](#stale-issue-label) or [stale-pr-label](#stale-pr-label) removed from it.
+
+Note: Each label results in a unique API call.
 
 Default value: unset
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Every argument is optional.
 | [remove-stale-when-updated](#remove-stale-when-updated)             | Remove stale label from issues/PRs on updates/comments                   | `true`                |
 | [remove-issue-stale-when-updated](#remove-issue-stale-when-updated) | Remove stale label from issues on updates/comments                       |                       |
 | [remove-pr-stale-when-updated](#remove-pr-stale-when-updated)       | Remove stale label from PRs on updates/comments                          |                       |
-| [labels-to-add-when-unstale](#labels-to-add-when-unstale)           | Add specified labels from issue/PR when they become unstale              |                       |
-| [labels-to-remove-when-unstale](#labels-to-remove-when-unstale)     | Remove specified labels from issue/PR when they become unstale           |                       |
+| [labels-to-add-when-unstale](#labels-to-add-when-unstale)           | Add specified labels from issues/PRs when they become unstale              |                       |
+| [labels-to-remove-when-unstale](#labels-to-remove-when-unstale)     | Remove specified labels from issues/PRs when they become unstale           |                       |
 | [debug-only](#debug-only)                                           | Dry-run                                                                  | `false`               |
 | [ascending](#ascending)                                             | Order to get issues/PRs                                                  | `false`               |
 | [start-date](#start-date)                                           | Skip stale action for issues/PRs created before it                       |                       |
@@ -311,15 +311,15 @@ Default value: unset
 
 #### labels-to-add-when-unstale
 
-A comma delimited list of labels to add when a stale issue receives activity and has the [stale-issue-label](#stale-issue-label) or [stale-pr-label](#stale-pr-label) removed from it.
+A comma delimited list of labels to add when a stale issue or pull request receives activity and has the [stale-issue-label](#stale-issue-label) or [stale-pr-label](#stale-pr-label) removed from it.
 
 Default value: unset
 
 #### labels-to-remove-when-unstale
 
-A comma delimited list of labels to remove when a stale issue receives activity and has the [stale-issue-label](#stale-issue-label) or [stale-pr-label](#stale-pr-label) removed from it.
+A comma delimited list of labels to remove when a stale issue or pull request receives activity and has the [stale-issue-label](#stale-issue-label) or [stale-pr-label](#stale-pr-label) removed from it.
 
-Note: Each label results in a unique API call.
+Warning: each label results in a unique API call which can drastically consume the limit of [operations-per-run](#operations-per-run).
 
 Default value: unset
 

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -45,6 +45,6 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   exemptAllIssueAssignees: undefined,
   exemptAllPrAssignees: undefined,
   enableStatistics: true,
-  removeLabelsWhenUnstale: '',
-  addLabelsWhenUnstale: ''
+  labelsToRemoveWhenUnstale: '',
+  labelsToAddWhenUnstale: ''
 });

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -45,6 +45,6 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   exemptAllIssueAssignees: undefined,
   exemptAllPrAssignees: undefined,
   enableStatistics: true,
-  removeLabelsWhenUpdatedFromStale: '',
-  addLabelsWhenUpdatedFromStale: ''
+  removeLabelsWhenUnstale: '',
+  addLabelsWhenUnstale: ''
 });

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -44,5 +44,7 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   exemptAllAssignees: false,
   exemptAllIssueAssignees: undefined,
   exemptAllPrAssignees: undefined,
-  enableStatistics: true
+  enableStatistics: true,
+  removeLabelsWhenUpdatedFromStale: '',
+  addLabelsWhenUpdatedFromStale: ''
 });

--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -1255,7 +1255,7 @@ test('stale label should be removed if a comment was added to a stale issue', as
   expect(processor.removedLabelIssues).toHaveLength(1);
 });
 
-test('if specified, labels should be added when unstale', async () => {
+test('when the option "labelsToAddWhenUnstale" is set, the labels should be added when unstale', async () => {
   const opts = {
     ...DefaultProcessorOptions,
     removeStaleWhenUpdated: true,

--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -1256,6 +1256,7 @@ test('stale label should be removed if a comment was added to a stale issue', as
 });
 
 test('when the option "labelsToAddWhenUnstale" is set, the labels should be added when unstale', async () => {
+  expect.assertions(4);
   const opts = {
     ...DefaultProcessorOptions,
     removeStaleWhenUpdated: true,

--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -1259,7 +1259,7 @@ test('if specified, labels should be added when unstale', async () => {
   const opts = {
     ...DefaultProcessorOptions,
     removeStaleWhenUpdated: true,
-    addLabelsWhenUnstale: 'test'
+    labelsToAddWhenUnstale: 'test'
   };
   const TestIssueList: Issue[] = [
     generateIssue(

--- a/dist/index.js
+++ b/dist/index.js
@@ -1726,6 +1726,8 @@ var Option;
     Option["ExemptAllIssueAssignees"] = "exempt-all-issue-assignees";
     Option["ExemptAllPrAssignees"] = "exempt-all-pr-assignees";
     Option["EnableStatistics"] = "enable-statistics";
+    Option["RemoveLabelsWhenUpdatedFromStale"] = "remove-labels-when-updated-from-stale";
+    Option["AddLabelsWhenUpdatedFromStale"] = "add-labels-when-updated-from-stale";
 })(Option = exports.Option || (exports.Option = {}));
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -878,14 +878,20 @@ class IssuesProcessor {
                 return;
             }
             const issueLogger = new issue_logger_1.IssueLogger(issue);
-            issueLogger.info(`Adding labels marked as add-labels-when-updated-from-stale...`);
-            (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsLabel(issue);
-            yield this.client.issues.addLabels({
-                owner: github_1.context.repo.owner,
-                repo: github_1.context.repo.repo,
-                issue_number: issue.number,
-                labels: labelsToAdd
-            });
+            issueLogger.info(`Removing all the labels specified via the ${this._logger.createOptionLink(option_1.Option.AddLabelsWhenUpdatedFromStale)}`);
+            try {
+                this._operations.consumeOperation();
+                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsLabel(issue);
+                yield this.client.issues.addLabels({
+                    owner: github_1.context.repo.owner,
+                    repo: github_1.context.repo.repo,
+                    issue_number: issue.number,
+                  labels: labelsToAdd
+                });
+            }
+            catch (error) {
+                this._logger.error(`Add labels when updated from stale error: ${error.message}`);
+            }
         });
     }
     _removeStaleLabel(issue, staleLabel) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -865,7 +865,7 @@ class IssuesProcessor {
                 return;
             }
             const issueLogger = new issue_logger_1.IssueLogger(issue);
-            issueLogger.info(`Removing any labels specified via remove-labels-when-updated-from-stale...`);
+            issueLogger.info(`Removing all the labels specified via the ${this._logger.createOptionLink(option_1.Option.RemoveLabelsWhenUpdatedFromStale)}`);
             for (const label of removeLabels.values()) {
                 yield this._removeLabel(issue, label);
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -859,14 +859,14 @@ class IssuesProcessor {
         }
         return this.options.removeStaleWhenUpdated;
     }
-    _removeLabelsWhenUpdatedFromStale(issue, labels) {
+    _removeLabelsWhenUpdatedFromStale(issue, removeLabels) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (!labels.length) {
+            if (!removeLabels.length) {
                 return;
             }
             const issueLogger = new issue_logger_1.IssueLogger(issue);
             issueLogger.info(`Removing any labels specified via remove-labels-when-updated-from-stale...`);
-            for (const label of labels.values()) {
+            for (const label of removeLabels.values()) {
                 yield this._removeLabel(issue, label);
             }
         });

--- a/dist/index.js
+++ b/dist/index.js
@@ -299,6 +299,8 @@ class IssuesProcessor {
             else {
                 this._logger.info(`${logger_service_1.LoggerService.yellow('Processing the batch of issues')} ${logger_service_1.LoggerService.cyan(`#${page}`)} ${logger_service_1.LoggerService.yellow('containing')} ${logger_service_1.LoggerService.cyan(issues.length)} ${logger_service_1.LoggerService.yellow(`issue${issues.length > 1 ? 's' : ''}...`)}`);
             }
+            const addLabelsWhenUpdated = words_to_list_1.wordsToList(this.options.addLabelsWhenUpdatedFromStale);
+            const removeLabelsWhenUpdated = words_to_list_1.wordsToList(this.options.removeLabelsWhenUpdatedFromStale);
             for (const issue of issues.values()) {
                 // Stop the processing if no more operations remains
                 if (!this.operations.hasRemainingOperations()) {
@@ -306,7 +308,7 @@ class IssuesProcessor {
                 }
                 const issueLogger = new issue_logger_1.IssueLogger(issue);
                 yield issueLogger.grouping(`$$type #${issue.number}`, () => __awaiter(this, void 0, void 0, function* () {
-                    yield this.processIssue(issue, actor);
+                    yield this.processIssue(issue, actor, addLabelsWhenUpdated, removeLabelsWhenUpdated);
                 }));
             }
             if (!this.operations.hasRemainingOperations()) {
@@ -320,7 +322,7 @@ class IssuesProcessor {
             return this.processIssues(page + 1);
         });
     }
-    processIssue(issue, actor) {
+    processIssue(issue, actor, addLabelsWhenUpdated, removeLabelsWhenUpdated) {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
             (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementProcessedItemsCount(issue);
@@ -469,7 +471,7 @@ class IssuesProcessor {
             // Process the issue if it was marked stale
             if (issue.isStale) {
                 issueLogger.info(`This $$type is already stale`);
-                yield this._processStaleIssue(issue, staleLabel, actor, closeMessage, closeLabel);
+                yield this._processStaleIssue(issue, staleLabel, actor, addLabelsWhenUpdated, removeLabelsWhenUpdated, closeMessage, closeLabel);
             }
             IssuesProcessor._endIssueProcessing(issue);
         });
@@ -561,7 +563,7 @@ class IssuesProcessor {
         });
     }
     // handle all of the stale issue logic when we find a stale issue
-    _processStaleIssue(issue, staleLabel, actor, closeMessage, closeLabel) {
+    _processStaleIssue(issue, staleLabel, actor, addLabelsWhenUpdatedFromStale, removeLabelsWhenUpdatedFromStale, closeMessage, closeLabel) {
         return __awaiter(this, void 0, void 0, function* () {
             const issueLogger = new issue_logger_1.IssueLogger(issue);
             const markedStaleOn = (yield this.getLabelCreationDate(issue, staleLabel)) || issue.updated_at;
@@ -586,6 +588,9 @@ class IssuesProcessor {
             if (shouldRemoveStaleWhenUpdated && issueHasComments) {
                 issueLogger.info(`Remove the stale label since the $$type has a comment and the workflow should remove the stale label when updated`);
                 yield this._removeStaleLabel(issue, staleLabel);
+                // Are there labels to remove or add when an issue is no longer stale?
+                yield this._removeLabelsWhenUpdatedFromStale(issue, removeLabelsWhenUpdatedFromStale);
+                yield this._addLabelsWhenUpdatedFromStale(issue, addLabelsWhenUpdatedFromStale);
                 issueLogger.info(`Skipping the process since the $$type is now un-stale`);
                 return; // Nothing to do because it is no longer stale
             }
@@ -853,6 +858,35 @@ class IssuesProcessor {
             return this.options.removeIssueStaleWhenUpdated;
         }
         return this.options.removeStaleWhenUpdated;
+    }
+    _removeLabelsWhenUpdatedFromStale(issue, labels) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!labels.length) {
+                return;
+            }
+            const issueLogger = new issue_logger_1.IssueLogger(issue);
+            issueLogger.info(`Removing any labels specified via remove-labels-when-updated-from-stale...`);
+            for (const label of labels.values()) {
+                yield this._removeLabel(issue, label);
+            }
+        });
+    }
+    _addLabelsWhenUpdatedFromStale(issue, labelsToAdd) {
+        var _a;
+        return __awaiter(this, void 0, void 0, function* () {
+            if (!labelsToAdd.length) {
+                return;
+            }
+            const issueLogger = new issue_logger_1.IssueLogger(issue);
+            issueLogger.info(`Adding labels marked as add-labels-when-updated-from-stale...`);
+            (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsLabel(issue);
+            yield this.client.issues.addLabels({
+                owner: github_1.context.repo.owner,
+                repo: github_1.context.repo.repo,
+                issue_number: issue.number,
+                labels: labelsToAdd
+            });
+        });
     }
     _removeStaleLabel(issue, staleLabel) {
         var _a;
@@ -1975,7 +2009,9 @@ function _getAndValidateArgs() {
         exemptAllAssignees: core.getInput('exempt-all-assignees') === 'true',
         exemptAllIssueAssignees: _toOptionalBoolean('exempt-all-issue-assignees'),
         exemptAllPrAssignees: _toOptionalBoolean('exempt-all-pr-assignees'),
-        enableStatistics: core.getInput('enable-statistics') === 'true'
+        enableStatistics: core.getInput('enable-statistics') === 'true',
+        removeLabelsWhenUpdatedFromStale: core.getInput('remove-labels-when-updated-from-stale'),
+        addLabelsWhenUpdatedFromStale: core.getInput('add-labels-when-updated-from-stale')
     };
     for (const numberInput of [
         'days-before-stale',

--- a/dist/index.js
+++ b/dist/index.js
@@ -879,20 +879,19 @@ class IssuesProcessor {
                 return;
             }
             const issueLogger = new issue_logger_1.IssueLogger(issue);
-            issueLogger.info(`Removing all the labels specified via the ${this._logger.createOptionLink(option_1.Option.LabelsToAddWhenUnstale)} option.`);
+            issueLogger.info(`Adding all the labels specified via the ${this._logger.createOptionLink(option_1.Option.LabelsToAddWhenUnstale)} option.`);
             this.addedLabelIssues.push(issue);
-            if (this.options.debugOnly) {
-                return;
-            }
             try {
                 this.operations.consumeOperation();
                 (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsLabel(issue);
-                yield this.client.issues.addLabels({
-                    owner: github_1.context.repo.owner,
-                    repo: github_1.context.repo.repo,
-                    issue_number: issue.number,
-                    labels: labelsToAdd
-                });
+                if (!this.options.debugOnly) {
+                    yield this.client.issues.addLabels({
+                        owner: github_1.context.repo.owner,
+                        repo: github_1.context.repo.repo,
+                        issue_number: issue.number,
+                        labels: labelsToAdd
+                    });
+                }
             }
             catch (error) {
                 this._logger.error(`Error when adding labels after updated from stale: ${error.message}`);

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -56,8 +56,8 @@ describe('Issue', (): void => {
       exemptAllIssueAssignees: undefined,
       exemptAllPrAssignees: undefined,
       enableStatistics: false,
-      removeLabelsWhenUnstale: '',
-      addLabelsWhenUnstale: ''
+      labelsToRemoveWhenUnstale: '',
+      labelsToAddWhenUnstale: ''
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -55,7 +55,9 @@ describe('Issue', (): void => {
       exemptAllAssignees: false,
       exemptAllIssueAssignees: undefined,
       exemptAllPrAssignees: undefined,
-      enableStatistics: false
+      enableStatistics: false,
+      removeLabelsWhenUpdatedFromStale: '',
+      addLabelsWhenUpdatedFromStale: ''
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -56,8 +56,8 @@ describe('Issue', (): void => {
       exemptAllIssueAssignees: undefined,
       exemptAllPrAssignees: undefined,
       enableStatistics: false,
-      removeLabelsWhenUpdatedFromStale: '',
-      addLabelsWhenUpdatedFromStale: ''
+      removeLabelsWhenUnstale: '',
+      addLabelsWhenUnstale: ''
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -1019,16 +1019,25 @@ export class IssuesProcessor {
     const issueLogger: IssueLogger = new IssueLogger(issue);
 
     issueLogger.info(
-      `Adding labels marked as add-labels-when-updated-from-stale...`
+      `Removing all the labels specified via the ${this._logger.createOptionLink(
+        Option.AddLabelsWhenUpdatedFromStale
+      )}`
     );
 
-    this._statistics?.incrementAddedItemsLabel(issue);
-    await this.client.issues.addLabels({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      issue_number: issue.number,
-      labels: labelsToAdd
-    });
+    try {
+      this.operations.consumeOperation();
+      this._statistics?.incrementAddedItemsLabel(issue);
+      await this.client.issues.addLabels({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: issue.number,
+        labels: labelsToAdd
+      });
+    } catch (error) {
+      this._logger.error(
+        `Add labels when updated from stale error: ${error.message}`
+      );
+    }
   }
 
   private async _removeStaleLabel(

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -989,9 +989,9 @@ export class IssuesProcessor {
 
   private async _removeLabelsWhenUpdatedFromStale(
     issue: Issue,
-    labels: Readonly<string>[]
+    removeLabels: Readonly<string>[]
   ): Promise<void> {
-    if (!labels.length) {
+    if (!removeLabels.length) {
       return;
     }
 
@@ -1001,7 +1001,7 @@ export class IssuesProcessor {
       `Removing any labels specified via remove-labels-when-updated-from-stale...`
     );
 
-    for (const label of labels.values()) {
+    for (const label of removeLabels.values()) {
       await this._removeLabel(issue, label);
     }
   }

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -127,11 +127,11 @@ export class IssuesProcessor {
       );
     }
 
-    const addLabelsWhenUpdated: string[] = wordsToList(
-      this.options.addLabelsWhenUpdatedFromStale
+    const addLabelsWhenUnstale: string[] = wordsToList(
+      this.options.addLabelsWhenUnstale
     );
-    const removeLabelsWhenUpdated: string[] = wordsToList(
-      this.options.removeLabelsWhenUpdatedFromStale
+    const removeLabelsWhenUnstale: string[] = wordsToList(
+      this.options.removeLabelsWhenUnstale
     );
 
     for (const issue of issues.values()) {
@@ -145,8 +145,8 @@ export class IssuesProcessor {
         await this.processIssue(
           issue,
           actor,
-          addLabelsWhenUpdated,
-          removeLabelsWhenUpdated
+          addLabelsWhenUnstale,
+          removeLabelsWhenUnstale
         );
       });
     }
@@ -184,8 +184,8 @@ export class IssuesProcessor {
   async processIssue(
     issue: Issue,
     actor: string,
-    addLabelsWhenUpdated: Readonly<string>[],
-    removeLabelsWhenUpdated: Readonly<string>[]
+    addLabelsWhenUnstale: Readonly<string>[],
+    removeLabelsWhenUnstale: Readonly<string>[]
   ): Promise<void> {
     this._statistics?.incrementProcessedItemsCount(issue);
 
@@ -455,8 +455,8 @@ export class IssuesProcessor {
         issue,
         staleLabel,
         actor,
-        addLabelsWhenUpdated,
-        removeLabelsWhenUpdated,
+        addLabelsWhenUnstale,
+        removeLabelsWhenUnstale,
         closeMessage,
         closeLabel
       );
@@ -568,8 +568,8 @@ export class IssuesProcessor {
     issue: Issue,
     staleLabel: string,
     actor: string,
-    addLabelsWhenUpdatedFromStale: Readonly<string>[],
-    removeLabelsWhenUpdatedFromStale: Readonly<string>[],
+    addLabelsWhenUnstale: Readonly<string>[],
+    removeLabelsWhenUnstale: Readonly<string>[],
     closeMessage?: string,
     closeLabel?: string
   ) {
@@ -630,14 +630,8 @@ export class IssuesProcessor {
       await this._removeStaleLabel(issue, staleLabel);
 
       // Are there labels to remove or add when an issue is no longer stale?
-      await this._removeLabelsWhenUpdatedFromStale(
-        issue,
-        removeLabelsWhenUpdatedFromStale
-      );
-      await this._addLabelsWhenUpdatedFromStale(
-        issue,
-        addLabelsWhenUpdatedFromStale
-      );
+      await this._removeLabelsWhenUnstale(issue, removeLabelsWhenUnstale);
+      await this._addLabelsWhenUnstale(issue, addLabelsWhenUnstale);
 
       issueLogger.info(`Skipping the process since the $$type is now un-stale`);
 
@@ -987,7 +981,7 @@ export class IssuesProcessor {
     return this.options.removeStaleWhenUpdated;
   }
 
-  private async _removeLabelsWhenUpdatedFromStale(
+  private async _removeLabelsWhenUnstale(
     issue: Issue,
     removeLabels: Readonly<string>[]
   ): Promise<void> {
@@ -999,7 +993,7 @@ export class IssuesProcessor {
 
     issueLogger.info(
       `Removing all the labels specified via the ${this._logger.createOptionLink(
-        Option.RemoveLabelsWhenUpdatedFromStale
+        Option.RemoveLabelsWhenUnstale
       )}`
     );
 
@@ -1008,7 +1002,7 @@ export class IssuesProcessor {
     }
   }
 
-  private async _addLabelsWhenUpdatedFromStale(
+  private async _addLabelsWhenUnstale(
     issue: Issue,
     labelsToAdd: Readonly<string>[]
   ): Promise<void> {
@@ -1020,7 +1014,7 @@ export class IssuesProcessor {
 
     issueLogger.info(
       `Removing all the labels specified via the ${this._logger.createOptionLink(
-        Option.AddLabelsWhenUpdatedFromStale
+        Option.AddLabelsWhenUnstale
       )}`
     );
 

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -128,11 +128,11 @@ export class IssuesProcessor {
       );
     }
 
-    const addLabelsWhenUnstale: string[] = wordsToList(
-      this.options.addLabelsWhenUnstale
+    const labelsToAddWhenUnstale: string[] = wordsToList(
+      this.options.labelsToAddWhenUnstale
     );
-    const removeLabelsWhenUnstale: string[] = wordsToList(
-      this.options.removeLabelsWhenUnstale
+    const labelsToRemoveWhenUnstale: string[] = wordsToList(
+      this.options.labelsToRemoveWhenUnstale
     );
 
     for (const issue of issues.values()) {
@@ -146,8 +146,8 @@ export class IssuesProcessor {
         await this.processIssue(
           issue,
           actor,
-          addLabelsWhenUnstale,
-          removeLabelsWhenUnstale
+          labelsToAddWhenUnstale,
+          labelsToRemoveWhenUnstale
         );
       });
     }
@@ -185,8 +185,8 @@ export class IssuesProcessor {
   async processIssue(
     issue: Issue,
     actor: string,
-    addLabelsWhenUnstale: Readonly<string>[],
-    removeLabelsWhenUnstale: Readonly<string>[]
+    labelsToAddWhenUnstale: Readonly<string>[],
+    labelsToRemoveWhenUnstale: Readonly<string>[]
   ): Promise<void> {
     this._statistics?.incrementProcessedItemsCount(issue);
 
@@ -456,8 +456,8 @@ export class IssuesProcessor {
         issue,
         staleLabel,
         actor,
-        addLabelsWhenUnstale,
-        removeLabelsWhenUnstale,
+        labelsToAddWhenUnstale,
+        labelsToRemoveWhenUnstale,
         closeMessage,
         closeLabel
       );
@@ -569,8 +569,8 @@ export class IssuesProcessor {
     issue: Issue,
     staleLabel: string,
     actor: string,
-    addLabelsWhenUnstale: Readonly<string>[],
-    removeLabelsWhenUnstale: Readonly<string>[],
+    labelsToAddWhenUnstale: Readonly<string>[],
+    labelsToRemoveWhenUnstale: Readonly<string>[],
     closeMessage?: string,
     closeLabel?: string
   ) {
@@ -631,8 +631,8 @@ export class IssuesProcessor {
       await this._removeStaleLabel(issue, staleLabel);
 
       // Are there labels to remove or add when an issue is no longer stale?
-      await this._removeLabelsWhenUnstale(issue, removeLabelsWhenUnstale);
-      await this._addLabelsWhenUnstale(issue, addLabelsWhenUnstale);
+      await this._removeLabelsWhenUnstale(issue, labelsToRemoveWhenUnstale);
+      await this._addLabelsWhenUnstale(issue, labelsToAddWhenUnstale);
 
       issueLogger.info(`Skipping the process since the $$type is now un-stale`);
 
@@ -994,7 +994,7 @@ export class IssuesProcessor {
 
     issueLogger.info(
       `Removing all the labels specified via the ${this._logger.createOptionLink(
-        Option.RemoveLabelsWhenUnstale
+        Option.LabelsToRemoveWhenUnstale
       )} option.`
     );
 
@@ -1015,7 +1015,7 @@ export class IssuesProcessor {
 
     issueLogger.info(
       `Removing all the labels specified via the ${this._logger.createOptionLink(
-        Option.AddLabelsWhenUnstale
+        Option.LabelsToAddWhenUnstale
       )} option.`
     );
 

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -1018,6 +1018,10 @@ export class IssuesProcessor {
       )}`
     );
 
+    if (this.options.debugOnly) {
+      return;
+    }
+
     try {
       this.operations.consumeOperation();
       this._statistics?.incrementAddedItemsLabel(issue);

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -995,7 +995,7 @@ export class IssuesProcessor {
     issueLogger.info(
       `Removing all the labels specified via the ${this._logger.createOptionLink(
         Option.RemoveLabelsWhenUnstale
-      )}`
+      )} option.`
     );
 
     for (const label of removeLabels.values()) {
@@ -1016,7 +1016,7 @@ export class IssuesProcessor {
     issueLogger.info(
       `Removing all the labels specified via the ${this._logger.createOptionLink(
         Option.AddLabelsWhenUnstale
-      )}`
+      )} option.`
     );
 
     this.addedLabelIssues.push(issue);
@@ -1036,7 +1036,7 @@ export class IssuesProcessor {
       });
     } catch (error) {
       this._logger.error(
-        `Add labels when updated from stale error: ${error.message}`
+        `Error when adding labels after updated from stale: ${error.message}`
       );
     }
   }

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -75,6 +75,7 @@ export class IssuesProcessor {
   readonly closedIssues: Issue[] = [];
   readonly deletedBranchIssues: Issue[] = [];
   readonly removedLabelIssues: Issue[] = [];
+  readonly addedLabelIssues: Issue[] = [];
 
   constructor(options: IIssuesProcessorOptions) {
     this.options = options;
@@ -1017,6 +1018,8 @@ export class IssuesProcessor {
         Option.AddLabelsWhenUnstale
       )}`
     );
+
+    this.addedLabelIssues.push(issue);
 
     if (this.options.debugOnly) {
       return;

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -998,7 +998,9 @@ export class IssuesProcessor {
     const issueLogger: IssueLogger = new IssueLogger(issue);
 
     issueLogger.info(
-      `Removing any labels specified via remove-labels-when-updated-from-stale...`
+      `Removing all the labels specified via the ${this._logger.createOptionLink(
+        Option.RemoveLabelsWhenUpdatedFromStale
+      )}`
     );
 
     for (const label of removeLabels.values()) {

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -1021,19 +1021,17 @@ export class IssuesProcessor {
 
     this.addedLabelIssues.push(issue);
 
-    if (this.options.debugOnly) {
-      return;
-    }
-
     try {
       this.operations.consumeOperation();
       this._statistics?.incrementAddedItemsLabel(issue);
-      await this.client.issues.addLabels({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        issue_number: issue.number,
-        labels: labelsToAdd
-      });
+      if (!this.options.debugOnly) {
+        await this.client.issues.addLabels({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: issue.number,
+          labels: labelsToAdd
+        });
+      }
     } catch (error) {
       this._logger.error(
         `Error when adding labels after updated from stale: ${error.message}`

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -1014,7 +1014,7 @@ export class IssuesProcessor {
     const issueLogger: IssueLogger = new IssueLogger(issue);
 
     issueLogger.info(
-      `Removing all the labels specified via the ${this._logger.createOptionLink(
+      `Adding all the labels specified via the ${this._logger.createOptionLink(
         Option.LabelsToAddWhenUnstale
       )} option.`
     );

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -41,6 +41,6 @@ export enum Option {
   ExemptAllIssueAssignees = 'exempt-all-issue-assignees',
   ExemptAllPrAssignees = 'exempt-all-pr-assignees',
   EnableStatistics = 'enable-statistics',
-  RemoveLabelsWhenUpdatedFromStale = 'remove-labels-when-updated-from-stale',
-  AddLabelsWhenUpdatedFromStale = 'add-labels-when-updated-from-stale'
+  RemoveLabelsWhenUnstale = 'remove-labels-when-unstale',
+  AddLabelsWhenUnstale = 'add-labels-when-unstale'
 }

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -40,5 +40,7 @@ export enum Option {
   ExemptAllAssignees = 'exempt-all-assignees',
   ExemptAllIssueAssignees = 'exempt-all-issue-assignees',
   ExemptAllPrAssignees = 'exempt-all-pr-assignees',
-  EnableStatistics = 'enable-statistics'
+  EnableStatistics = 'enable-statistics',
+  RemoveLabelsWhenUpdatedFromStale = 'remove-labels-when-updated-from-stale',
+  AddLabelsWhenUpdatedFromStale = 'add-labels-when-updated-from-stale'
 }

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -41,6 +41,6 @@ export enum Option {
   ExemptAllIssueAssignees = 'exempt-all-issue-assignees',
   ExemptAllPrAssignees = 'exempt-all-pr-assignees',
   EnableStatistics = 'enable-statistics',
-  RemoveLabelsWhenUnstale = 'remove-labels-when-unstale',
-  AddLabelsWhenUnstale = 'add-labels-when-unstale'
+  LabelsToRemoveWhenUnstale = 'labels-to-remove-when-unstale',
+  LabelsToAddWhenUnstale = 'labels-to-add-when-unstale'
 }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -45,4 +45,6 @@ export interface IIssuesProcessorOptions {
   exemptAllIssueAssignees: boolean | undefined;
   exemptAllPrAssignees: boolean | undefined;
   enableStatistics: boolean;
+  removeLabelsWhenUpdatedFromStale: string;
+  addLabelsWhenUpdatedFromStale: string;
 }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -45,6 +45,6 @@ export interface IIssuesProcessorOptions {
   exemptAllIssueAssignees: boolean | undefined;
   exemptAllPrAssignees: boolean | undefined;
   enableStatistics: boolean;
-  removeLabelsWhenUpdatedFromStale: string;
-  addLabelsWhenUpdatedFromStale: string;
+  removeLabelsWhenUnstale: string;
+  addLabelsWhenUnstale: string;
 }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -45,6 +45,6 @@ export interface IIssuesProcessorOptions {
   exemptAllIssueAssignees: boolean | undefined;
   exemptAllPrAssignees: boolean | undefined;
   enableStatistics: boolean;
-  removeLabelsWhenUnstale: string;
-  addLabelsWhenUnstale: string;
+  labelsToRemoveWhenUnstale: string;
+  labelsToAddWhenUnstale: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,8 +82,8 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     exemptAllIssueAssignees: _toOptionalBoolean('exempt-all-issue-assignees'),
     exemptAllPrAssignees: _toOptionalBoolean('exempt-all-pr-assignees'),
     enableStatistics: core.getInput('enable-statistics') === 'true',
-    removeLabelsWhenUnstale: core.getInput('remove-labels-when-unstale'),
-    addLabelsWhenUnstale: core.getInput('add-labels-when-unstale')
+    labelsToRemoveWhenUnstale: core.getInput('labels-to-remove-when-unstale'),
+    labelsToAddWhenUnstale: core.getInput('labels-to-add-when-unstale')
   };
 
   for (const numberInput of [

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,7 +81,13 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     exemptAllAssignees: core.getInput('exempt-all-assignees') === 'true',
     exemptAllIssueAssignees: _toOptionalBoolean('exempt-all-issue-assignees'),
     exemptAllPrAssignees: _toOptionalBoolean('exempt-all-pr-assignees'),
-    enableStatistics: core.getInput('enable-statistics') === 'true'
+    enableStatistics: core.getInput('enable-statistics') === 'true',
+    removeLabelsWhenUpdatedFromStale: core.getInput(
+      'remove-labels-when-updated-from-stale'
+    ),
+    addLabelsWhenUpdatedFromStale: core.getInput(
+      'add-labels-when-updated-from-stale'
+    )
   };
 
   for (const numberInput of [

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,12 +82,8 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     exemptAllIssueAssignees: _toOptionalBoolean('exempt-all-issue-assignees'),
     exemptAllPrAssignees: _toOptionalBoolean('exempt-all-pr-assignees'),
     enableStatistics: core.getInput('enable-statistics') === 'true',
-    removeLabelsWhenUpdatedFromStale: core.getInput(
-      'remove-labels-when-updated-from-stale'
-    ),
-    addLabelsWhenUpdatedFromStale: core.getInput(
-      'add-labels-when-updated-from-stale'
-    )
+    removeLabelsWhenUnstale: core.getInput('remove-labels-when-unstale'),
+    addLabelsWhenUnstale: core.getInput('add-labels-when-unstale')
   };
 
   for (const numberInput of [


### PR DESCRIPTION
Fixes https://github.com/actions/stale/issues/460

## Changes
Add support for:
- labels-to-remove-when-unstale
- labels-to-add-when-unstale

## Context
In order to prevent scenarios like [this](https://github.com/actions/stale/issues/288) and to reduce the amount of upkeep required for maintainers, allow the action to remove/add labels to prevent marking issues stale over and over again. 

Example of an ideal scenario is this:

1. User submits issue
2. We respond and need author feedback, apply that label
3. Issue goes stale via automation
4. Author (or someone else with the same issue) responds suggesting it's still an issue
5. Automation should remove the `needs-author-feedback` label and add some `author-responded` or `needs-dev-response` label

This allows automation to ONLY run on `needs-author-feedback` issues, or be exempt on `author-responded` issues.