### PR TITLE
fix(logs): fix logs regarding updates and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ permissions:
   issues: read
   pull-requests: read
 ```
-  
+
 In addition, based on the provided configuration, the action could require more permission(s) (e.g.: add label, remove label, comment, close, etc.).  
 You can find more information about the required permissions under the corresponding options that you wish to use.  
 However, if don't want to bother, you can use these permissions:


### PR DESCRIPTION
## Changes

- [x] Fix some bad logs when tracking the updates and comments unstale step, fixes #503
- [x] Slightly improve the logs to have something like the example below:

```
[#1] Checking if the stale label should be removed...
[#1] ├──  Remove the stale label since the issue has a comment and the workflow should remove the stale label when commented
[#1] ├── The issue is no longer stale. Removing the stale label...
[#1] ├── Removing the label "Stale" from this issue...
[#1] ├── The label "Stale" was removed
[#1] └──  Skipping the process since the issue is now un-stale
```
