### PR TITLE
docs(stale-issue-comment): update the docs to remove that omitting the option will not send a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Warns and then closes issues and PRs that have had no activity for a specified a
 
 The configuration must be on the default branch and the default values will:
 
-- Add a label "Stale" on issues and pull requests after 60 days of inactivity
+- Add a label "Stale" on issues and pull requests after 60 days of inactivity and comment them
 - Close the stale issues and pull requests after 7 days of inactivity
 - If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart
 
@@ -175,7 +175,7 @@ Default value: unset
 
 The message that will be added as a comment to the issues when the stale workflow marks it automatically as stale with a label.
 
-You can skip the comment sending by omitting the option or by passing an empty string.
+You can skip the comment sending by passing an empty string.
 
 Default value: unset  
 Required Permission: `issues: write`
@@ -184,7 +184,7 @@ Required Permission: `issues: write`
 
 The message that will be added as a comment to the pull requests when the stale workflow marks it automatically as stale with a label.
 
-You can skip the comment sending by omitting the option or by passing an empty string.
+You can skip the comment sending by passing an empty string.
 
 Default value: unset  
 Required Permission: `pull-requests: write`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Warns and then closes issues and PRs that have had no activity for a specified a
 
 The configuration must be on the default branch and the default values will:
 
-- Add a label "Stale" on issues and pull requests after 60 days of inactivity and comment them
+- Add a label "Stale" on issues and pull requests after 60 days of inactivity and comment on them
 - Close the stale issues and pull requests after 7 days of inactivity
 - If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart
 

--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -2305,7 +2305,6 @@ test('processing a pull request to be stale with the "stalePrMessage" option set
   ];
   const processor = new IssuesProcessorMock(
     opts,
-    async () => 'abot',
     async p => (p === 1 ? TestIssueList : []),
     async () => [],
     async () => new Date().toDateString()
@@ -2316,7 +2315,7 @@ test('processing a pull request to be stale with the "stalePrMessage" option set
 
   expect(processor.staleIssues).toHaveLength(1);
   expect(processor.closedIssues).toHaveLength(0);
-  expect(processor.addedStaleCommentIssues).toHaveLength(1);
+  expect(processor.statistics?.addedPullRequestsCommentsCount).toStrictEqual(1);
 });
 
 test('processing a pull request to be stale with the "stalePrMessage" option set to empty will not send a PR comment', async () => {
@@ -2341,7 +2340,6 @@ test('processing a pull request to be stale with the "stalePrMessage" option set
   ];
   const processor = new IssuesProcessorMock(
     opts,
-    async () => 'abot',
     async p => (p === 1 ? TestIssueList : []),
     async () => [],
     async () => new Date().toDateString()
@@ -2352,5 +2350,5 @@ test('processing a pull request to be stale with the "stalePrMessage" option set
 
   expect(processor.staleIssues).toHaveLength(1);
   expect(processor.closedIssues).toHaveLength(0);
-  expect(processor.addedStaleCommentIssues).toHaveLength(0);
+  expect(processor.statistics?.addedPullRequestsCommentsCount).toStrictEqual(0);
 });

--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -2282,3 +2282,75 @@ test('processing an issue stale since less than the daysBeforeStale without a st
   expect(processor.deletedBranchIssues).toHaveLength(0);
   expect(processor.closedIssues).toHaveLength(0);
 });
+
+test('processing a pull request to be stale with the "stalePrMessage" option set will send a PR comment', async () => {
+  expect.assertions(3);
+  const opts: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    stalePrMessage: 'This PR is stale',
+    daysBeforeStale: 10,
+    daysBeforePrStale: 1
+  };
+  const issueDate = new Date();
+  issueDate.setDate(issueDate.getDate() - 2);
+  const TestIssueList: Issue[] = [
+    generateIssue(
+      opts,
+      1,
+      'A pull request with no label and a stale message',
+      issueDate.toDateString(),
+      issueDate.toDateString(),
+      true
+    )
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    async () => 'abot',
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [],
+    async () => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues).toHaveLength(1);
+  expect(processor.closedIssues).toHaveLength(0);
+  expect(processor.addedStaleCommentIssues).toHaveLength(1);
+});
+
+test('processing a pull request to be stale with the "stalePrMessage" option set to empty will not send a PR comment', async () => {
+  expect.assertions(3);
+  const opts: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    stalePrMessage: '',
+    daysBeforeStale: 10,
+    daysBeforePrStale: 1
+  };
+  const issueDate = new Date();
+  issueDate.setDate(issueDate.getDate() - 2);
+  const TestIssueList: Issue[] = [
+    generateIssue(
+      opts,
+      1,
+      'A pull request with no label and a stale message',
+      issueDate.toDateString(),
+      issueDate.toDateString(),
+      true
+    )
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    async () => 'abot',
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [],
+    async () => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues).toHaveLength(1);
+  expect(processor.closedIssues).toHaveLength(0);
+  expect(processor.addedStaleCommentIssues).toHaveLength(0);
+});

--- a/dist/index.js
+++ b/dist/index.js
@@ -263,7 +263,6 @@ exports.Issue = void 0;
 const is_labeled_1 = __nccwpck_require__(6792);
 const is_pull_request_1 = __nccwpck_require__(5400);
 const operations_1 = __nccwpck_require__(7957);
-const logger_1 = __nccwpck_require__(6212);
 class Issue {
     constructor(options, issue) {
         this.operations = new operations_1.Operations();
@@ -278,10 +277,6 @@ class Issue {
         this.locked = issue.locked;
         this.milestone = issue.milestone;
         this.assignees = issue.assignees;
-        // @todo remove this log
-        const logger = new logger_1.Logger();
-        logger.info('Assignees:');
-        logger.info(...this.assignees.map((assignee) => JSON.stringify(assignee)));
         this.isStale = is_labeled_1.isLabeled(this, this.staleLabel);
     }
     get isPullRequest() {
@@ -370,9 +365,8 @@ class IssuesProcessor {
         this.deletedBranchIssues = [];
         this.removedLabelIssues = [];
         this.addedLabelIssues = [];
-        this._logger = new logger_1.Logger();
-        this.addedStaleCommentIssues = [];
         this.addedCloseCommentIssues = [];
+        this._logger = new logger_1.Logger();
         this.options = options;
         this.client = github_1.getOctokit(this.options.repoToken);
         this.operations = new stale_operations_1.StaleOperations(this.options);
@@ -9178,12 +9172,12 @@ module.exports = require("zlib");;
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
-/******/
+/******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
 /******/ 	var __webpack_exports__ = __nccwpck_require__(3109);
 /******/ 	module.exports = __webpack_exports__;
-/******/
+/******/ 	
 /******/ })()
 ;

--- a/dist/index.js
+++ b/dist/index.js
@@ -371,6 +371,8 @@ class IssuesProcessor {
         this.removedLabelIssues = [];
         this.addedLabelIssues = [];
         this._logger = new logger_1.Logger();
+        this.addedStaleCommentIssues = [];
+        this.addedCloseCommentIssues = [];
         this.options = options;
         this.client = github_1.getOctokit(this.options.repoToken);
         this.operations = new stale_operations_1.StaleOperations(this.options);
@@ -790,6 +792,7 @@ class IssuesProcessor {
                 try {
                     this._consumeIssueOperation(issue);
                     (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsComment(issue);
+                    this.addedStaleCommentIssues.push(issue);
                     if (!this.options.debugOnly) {
                         yield this.client.issues.createComment({
                             owner: github_1.context.repo.owner,
@@ -832,6 +835,7 @@ class IssuesProcessor {
                 try {
                     this._consumeIssueOperation(issue);
                     (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsComment(issue);
+                    this.addedCloseCommentIssues.push(issue);
                     if (!this.options.debugOnly) {
                         yield this.client.issues.createComment({
                             owner: github_1.context.repo.owner,

--- a/dist/index.js
+++ b/dist/index.js
@@ -263,6 +263,7 @@ exports.Issue = void 0;
 const is_labeled_1 = __nccwpck_require__(6792);
 const is_pull_request_1 = __nccwpck_require__(5400);
 const operations_1 = __nccwpck_require__(7957);
+const logger_1 = __nccwpck_require__(6212);
 class Issue {
     constructor(options, issue) {
         this.operations = new operations_1.Operations();
@@ -277,6 +278,10 @@ class Issue {
         this.locked = issue.locked;
         this.milestone = issue.milestone;
         this.assignees = issue.assignees;
+        // @todo remove this log
+        const logger = new logger_1.Logger();
+        logger.info('Assignees:');
+        logger.info(...this.assignees.map((assignee) => JSON.stringify(assignee)));
         this.isStale = is_labeled_1.isLabeled(this, this.staleLabel);
     }
     get isPullRequest() {
@@ -879,7 +884,11 @@ class IssuesProcessor {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
             const issueLogger = new issue_logger_1.IssueLogger(issue);
-            issueLogger.info(`Delete branch from closed $$type - ${issue.title}`);
+            issueLogger.info(`Delete
+    branch from closed $
+    $type
+    -
+    ${issue.title}`);
             const pullRequest = yield this.getPullRequest(issue);
             if (!pullRequest) {
                 issueLogger.info(`Not deleting this branch as no pull request was found for this $$type`);
@@ -9147,12 +9156,12 @@ module.exports = require("zlib");;
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
-/******/ 	
+/******/
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
 /******/ 	// This entry module is referenced by other modules so it can't be inlined
 /******/ 	var __webpack_exports__ = __nccwpck_require__(3109);
 /******/ 	module.exports = __webpack_exports__;
-/******/ 	
+/******/
 /******/ })()
 ;

--- a/dist/index.js
+++ b/dist/index.js
@@ -691,7 +691,7 @@ class IssuesProcessor {
             const issueLogger = new issue_logger_1.IssueLogger(issue);
             try {
                 this._consumeIssueOperation(issue);
-                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedPullRequestsCount();
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedPullRequestsCount();
                 const pullRequest = yield this.client.pulls.get({
                     owner: github_1.context.repo.owner,
                     repo: github_1.context.repo.repo,
@@ -873,25 +873,6 @@ class IssuesProcessor {
             }
             catch (error) {
                 issueLogger.error(`Error when updating this $$type: ${error.message}`);
-            }
-        });
-    }
-    _getPullRequest(issue) {
-        var _a;
-        return __awaiter(this, void 0, void 0, function* () {
-            const issueLogger = new issue_logger_1.IssueLogger(issue);
-            try {
-                this._consumeIssueOperation(issue);
-                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedPullRequestsCount();
-                const pullRequest = yield this.client.pulls.get({
-                    owner: github_1.context.repo.owner,
-                    repo: github_1.context.repo.repo,
-                    pull_number: issue.number
-                });
-                return pullRequest.data;
-            }
-            catch (error) {
-                issueLogger.error(`Error when getting this $$type: ${error.message}`);
             }
         });
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -382,7 +382,7 @@ class IssuesProcessor {
             this._logger.warning(logger_service_1.LoggerService.yellowBright(`The debug output will be written but no issues/PRs will be processed.`));
         }
         if (this.options.enableStatistics) {
-            this._statistics = new statistics_1.Statistics();
+            this.statistics = new statistics_1.Statistics();
         }
     }
     static _updatedSince(timestamp, num_days) {
@@ -407,7 +407,7 @@ class IssuesProcessor {
             const issues = yield this.getIssues(page);
             if (issues.length <= 0) {
                 this._logger.info(logger_service_1.LoggerService.green(`No more issues found to process. Exiting...`));
-                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.setOperationsCount(this.operations.getConsumedOperationsCount()).logStats();
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.setOperationsCount(this.operations.getConsumedOperationsCount()).logStats();
                 return this.operations.getRemainingOperationsCount();
             }
             else {
@@ -428,7 +428,7 @@ class IssuesProcessor {
             if (!this.operations.hasRemainingOperations()) {
                 this._logger.warning(logger_service_1.LoggerService.yellowBright(`No more operations left! Exiting...`));
                 this._logger.warning(`${logger_service_1.LoggerService.yellowBright('If you think that not enough issues were processed you could try to increase the quantity related to the')} ${this._logger.createOptionLink(option_1.Option.OperationsPerRun)} ${logger_service_1.LoggerService.yellowBright('option which is currently set to')} ${logger_service_1.LoggerService.cyan(this.options.operationsPerRun)}`);
-                (_b = this._statistics) === null || _b === void 0 ? void 0 : _b.setOperationsCount(this.operations.getConsumedOperationsCount()).logStats();
+                (_b = this.statistics) === null || _b === void 0 ? void 0 : _b.setOperationsCount(this.operations.getConsumedOperationsCount()).logStats();
                 return 0;
             }
             this._logger.info(`${logger_service_1.LoggerService.green('Batch')} ${logger_service_1.LoggerService.cyan(`#${page}`)} ${logger_service_1.LoggerService.green('processed.')}`);
@@ -439,7 +439,7 @@ class IssuesProcessor {
     processIssue(issue, labelsToAddWhenUnstale, labelsToRemoveWhenUnstale) {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
-            (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementProcessedItemsCount(issue);
+            (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementProcessedItemsCount(issue);
             const issueLogger = new issue_logger_1.IssueLogger(issue);
             issueLogger.info(`Found this $$type last updated at: ${logger_service_1.LoggerService.cyan(issue.updated_at)}`);
             // calculate string based messages for this issue
@@ -625,7 +625,7 @@ class IssuesProcessor {
             // Find any comments since date on the given issue
             try {
                 this.operations.consumeOperation();
-                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCommentsCount();
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCommentsCount();
                 const comments = yield this.client.issues.listComments({
                     owner: github_1.context.repo.owner,
                     repo: github_1.context.repo.repo,
@@ -656,7 +656,7 @@ class IssuesProcessor {
                     direction: this.options.ascending ? 'asc' : 'desc',
                     page
                 });
-                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCount(issueResult.data.length);
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCount(issueResult.data.length);
                 return issueResult.data.map((issue) => new issue_1.Issue(this.options, issue));
             }
             catch (error) {
@@ -673,7 +673,7 @@ class IssuesProcessor {
             const issueLogger = new issue_logger_1.IssueLogger(issue);
             issueLogger.info(`Checking for label on this $$type`);
             this._consumeIssueOperation(issue);
-            (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsEventsCount();
+            (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsEventsCount();
             const options = this.client.issues.listEvents.endpoint.merge({
                 owner: github_1.context.repo.owner,
                 repo: github_1.context.repo.repo,
@@ -791,8 +791,7 @@ class IssuesProcessor {
             if (!skipMessage) {
                 try {
                     this._consumeIssueOperation(issue);
-                    (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsComment(issue);
-                    this.addedStaleCommentIssues.push(issue);
+                    (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsComment(issue);
                     if (!this.options.debugOnly) {
                         yield this.client.issues.createComment({
                             owner: github_1.context.repo.owner,
@@ -808,8 +807,8 @@ class IssuesProcessor {
             }
             try {
                 this._consumeIssueOperation(issue);
-                (_b = this._statistics) === null || _b === void 0 ? void 0 : _b.incrementAddedItemsLabel(issue);
-                (_c = this._statistics) === null || _c === void 0 ? void 0 : _c.incrementStaleItemsCount(issue);
+                (_b = this.statistics) === null || _b === void 0 ? void 0 : _b.incrementAddedItemsLabel(issue);
+                (_c = this.statistics) === null || _c === void 0 ? void 0 : _c.incrementStaleItemsCount(issue);
                 if (!this.options.debugOnly) {
                     yield this.client.issues.addLabels({
                         owner: github_1.context.repo.owner,
@@ -834,7 +833,7 @@ class IssuesProcessor {
             if (closeMessage) {
                 try {
                     this._consumeIssueOperation(issue);
-                    (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsComment(issue);
+                    (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsComment(issue);
                     this.addedCloseCommentIssues.push(issue);
                     if (!this.options.debugOnly) {
                         yield this.client.issues.createComment({
@@ -852,7 +851,7 @@ class IssuesProcessor {
             if (closeLabel) {
                 try {
                     this._consumeIssueOperation(issue);
-                    (_b = this._statistics) === null || _b === void 0 ? void 0 : _b.incrementAddedItemsLabel(issue);
+                    (_b = this.statistics) === null || _b === void 0 ? void 0 : _b.incrementAddedItemsLabel(issue);
                     if (!this.options.debugOnly) {
                         yield this.client.issues.addLabels({
                             owner: github_1.context.repo.owner,
@@ -868,7 +867,7 @@ class IssuesProcessor {
             }
             try {
                 this._consumeIssueOperation(issue);
-                (_c = this._statistics) === null || _c === void 0 ? void 0 : _c.incrementClosedItemsCount(issue);
+                (_c = this.statistics) === null || _c === void 0 ? void 0 : _c.incrementClosedItemsCount(issue);
                 if (!this.options.debugOnly) {
                     yield this.client.issues.update({
                         owner: github_1.context.repo.owner,
@@ -880,6 +879,25 @@ class IssuesProcessor {
             }
             catch (error) {
                 issueLogger.error(`Error when updating this $$type: ${error.message}`);
+            }
+        });
+    }
+    _getPullRequest(issue) {
+        var _a;
+        return __awaiter(this, void 0, void 0, function* () {
+            const issueLogger = new issue_logger_1.IssueLogger(issue);
+            try {
+                this._consumeIssueOperation(issue);
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedPullRequestsCount();
+                const pullRequest = yield this.client.pulls.get({
+                    owner: github_1.context.repo.owner,
+                    repo: github_1.context.repo.repo,
+                    pull_number: issue.number
+                });
+                return pullRequest.data;
+            }
+            catch (error) {
+                issueLogger.error(`Error when getting this $$type: ${error.message}`);
             }
         });
     }
@@ -902,7 +920,7 @@ class IssuesProcessor {
             issueLogger.info(`Deleting the branch "${logger_service_1.LoggerService.cyan(branch)}" from closed $$type`);
             try {
                 this._consumeIssueOperation(issue);
-                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementDeletedBranchesCount();
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementDeletedBranchesCount();
                 if (!this.options.debugOnly) {
                     yield this.client.git.deleteRef({
                         owner: github_1.context.repo.owner,
@@ -925,7 +943,7 @@ class IssuesProcessor {
             this.removedLabelIssues.push(issue);
             try {
                 this._consumeIssueOperation(issue);
-                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementDeletedItemsLabelsCount(issue);
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementDeletedItemsLabelsCount(issue);
                 if (!this.options.debugOnly) {
                     yield this.client.issues.removeLabel({
                         owner: github_1.context.repo.owner,
@@ -1022,7 +1040,7 @@ class IssuesProcessor {
             this.addedLabelIssues.push(issue);
             try {
                 this.operations.consumeOperation();
-                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsLabel(issue);
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsLabel(issue);
                 if (!this.options.debugOnly) {
                     yield this.client.issues.addLabels({
                         owner: github_1.context.repo.owner,
@@ -1043,7 +1061,7 @@ class IssuesProcessor {
             const issueLogger = new issue_logger_1.IssueLogger(issue);
             issueLogger.info(`The $$type is no longer stale. Removing the stale label...`);
             yield this._removeLabel(issue, staleLabel);
-            (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementUndoStaleItemsCount(issue);
+            (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementUndoStaleItemsCount(issue);
         });
     }
     _removeCloseLabel(issue, closeLabel) {
@@ -1059,7 +1077,7 @@ class IssuesProcessor {
             if (is_labeled_1.isLabeled(issue, closeLabel)) {
                 issueLogger.info(logger_service_1.LoggerService.white('├──'), `The $$type has a close label "${logger_service_1.LoggerService.cyan(closeLabel)}". Removing the close label...`);
                 yield this._removeLabel(issue, closeLabel, true);
-                (_a = this._statistics) === null || _a === void 0 ? void 0 : _a.incrementDeletedCloseItemsLabelsCount(issue);
+                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementDeletedCloseItemsLabelsCount(issue);
             }
             else {
                 issueLogger.info(logger_service_1.LoggerService.white('└──'), `There is no close label on this $$type. Skipping`);
@@ -1470,28 +1488,28 @@ const logger_service_1 = __nccwpck_require__(1973);
 class Statistics {
     constructor() {
         this._logger = new logger_1.Logger();
-        this._processedIssuesCount = 0;
-        this._processedPullRequestsCount = 0;
-        this._staleIssuesCount = 0;
-        this._stalePullRequestsCount = 0;
-        this._undoStaleIssuesCount = 0;
-        this._undoStalePullRequestsCount = 0;
-        this._operationsCount = 0;
-        this._closedIssuesCount = 0;
-        this._closedPullRequestsCount = 0;
-        this._deletedIssuesLabelsCount = 0;
-        this._deletedPullRequestsLabelsCount = 0;
-        this._deletedCloseIssuesLabelsCount = 0;
-        this._deletedClosePullRequestsLabelsCount = 0;
-        this._deletedBranchesCount = 0;
-        this._addedIssuesLabelsCount = 0;
-        this._addedPullRequestsLabelsCount = 0;
-        this._addedIssuesCommentsCount = 0;
-        this._addedPullRequestsCommentsCount = 0;
-        this._fetchedItemsCount = 0;
-        this._fetchedItemsEventsCount = 0;
-        this._fetchedItemsCommentsCount = 0;
-        this._fetchedPullRequestsCount = 0;
+        this.processedIssuesCount = 0;
+        this.processedPullRequestsCount = 0;
+        this.staleIssuesCount = 0;
+        this.stalePullRequestsCount = 0;
+        this.undoStaleIssuesCount = 0;
+        this.undoStalePullRequestsCount = 0;
+        this.operationsCount = 0;
+        this.closedIssuesCount = 0;
+        this.closedPullRequestsCount = 0;
+        this.deletedIssuesLabelsCount = 0;
+        this.deletedPullRequestsLabelsCount = 0;
+        this.deletedCloseIssuesLabelsCount = 0;
+        this.deletedClosePullRequestsLabelsCount = 0;
+        this.deletedBranchesCount = 0;
+        this.addedIssuesLabelsCount = 0;
+        this.addedPullRequestsLabelsCount = 0;
+        this.addedIssuesCommentsCount = 0;
+        this.addedPullRequestsCommentsCount = 0;
+        this.fetchedItemsCount = 0;
+        this.fetchedItemsEventsCount = 0;
+        this.fetchedItemsCommentsCount = 0;
+        this.fetchedPullRequestsCount = 0;
     }
     incrementProcessedItemsCount(issue, increment = 1) {
         if (issue.isPullRequest) {
@@ -1512,7 +1530,7 @@ class Statistics {
         return this._incrementUndoStaleIssuesCount(increment);
     }
     setOperationsCount(operationsCount) {
-        this._operationsCount = operationsCount;
+        this.operationsCount = operationsCount;
         return this;
     }
     incrementClosedItemsCount(issue, increment = 1) {
@@ -1534,7 +1552,7 @@ class Statistics {
         return this._incrementDeletedCloseIssuesLabelsCount(increment);
     }
     incrementDeletedBranchesCount(increment = 1) {
-        this._deletedBranchesCount += increment;
+        this.deletedBranchesCount += increment;
         return this;
     }
     incrementAddedItemsLabel(issue, increment = 1) {
@@ -1550,19 +1568,19 @@ class Statistics {
         return this._incrementAddedIssuesComment(increment);
     }
     incrementFetchedItemsCount(increment = 1) {
-        this._fetchedItemsCount += increment;
+        this.fetchedItemsCount += increment;
         return this;
     }
     incrementFetchedItemsEventsCount(increment = 1) {
-        this._fetchedItemsEventsCount += increment;
+        this.fetchedItemsEventsCount += increment;
         return this;
     }
     incrementFetchedItemsCommentsCount(increment = 1) {
-        this._fetchedItemsCommentsCount += increment;
+        this.fetchedItemsCommentsCount += increment;
         return this;
     }
     incrementFetchedPullRequestsCount(increment = 1) {
-        this._fetchedPullRequestsCount += increment;
+        this.fetchedPullRequestsCount += increment;
         return this;
     }
     logStats() {
@@ -1584,78 +1602,78 @@ class Statistics {
         return this;
     }
     _incrementProcessedIssuesCount(increment = 1) {
-        this._processedIssuesCount += increment;
+        this.processedIssuesCount += increment;
         return this;
     }
     _incrementProcessedPullRequestsCount(increment = 1) {
-        this._processedPullRequestsCount += increment;
+        this.processedPullRequestsCount += increment;
         return this;
     }
     _incrementStaleIssuesCount(increment = 1) {
-        this._staleIssuesCount += increment;
+        this.staleIssuesCount += increment;
         return this;
     }
     _incrementStalePullRequestsCount(increment = 1) {
-        this._stalePullRequestsCount += increment;
+        this.stalePullRequestsCount += increment;
         return this;
     }
     _incrementUndoStaleIssuesCount(increment = 1) {
-        this._undoStaleIssuesCount += increment;
+        this.undoStaleIssuesCount += increment;
         return this;
     }
     _incrementUndoStalePullRequestsCount(increment = 1) {
-        this._undoStalePullRequestsCount += increment;
+        this.undoStalePullRequestsCount += increment;
         return this;
     }
     _incrementClosedIssuesCount(increment = 1) {
-        this._closedIssuesCount += increment;
+        this.closedIssuesCount += increment;
         return this;
     }
     _incrementClosedPullRequestsCount(increment = 1) {
-        this._closedPullRequestsCount += increment;
+        this.closedPullRequestsCount += increment;
         return this;
     }
     _incrementDeletedIssuesLabelsCount(increment = 1) {
-        this._deletedIssuesLabelsCount += increment;
+        this.deletedIssuesLabelsCount += increment;
         return this;
     }
     _incrementDeletedPullRequestsLabelsCount(increment = 1) {
-        this._deletedPullRequestsLabelsCount += increment;
+        this.deletedPullRequestsLabelsCount += increment;
         return this;
     }
     _incrementDeletedCloseIssuesLabelsCount(increment = 1) {
-        this._deletedCloseIssuesLabelsCount += increment;
+        this.deletedCloseIssuesLabelsCount += increment;
         return this;
     }
     _incrementDeletedClosePullRequestsLabelsCount(increment = 1) {
-        this._deletedClosePullRequestsLabelsCount += increment;
+        this.deletedClosePullRequestsLabelsCount += increment;
         return this;
     }
     _incrementAddedIssuesLabel(increment = 1) {
-        this._addedIssuesLabelsCount += increment;
+        this.addedIssuesLabelsCount += increment;
         return this;
     }
     _incrementAddedPullRequestsLabel(increment = 1) {
-        this._addedPullRequestsLabelsCount += increment;
+        this.addedPullRequestsLabelsCount += increment;
         return this;
     }
     _incrementAddedIssuesComment(increment = 1) {
-        this._addedIssuesCommentsCount += increment;
+        this.addedIssuesCommentsCount += increment;
         return this;
     }
     _incrementAddedPullRequestsComment(increment = 1) {
-        this._addedPullRequestsCommentsCount += increment;
+        this.addedPullRequestsCommentsCount += increment;
         return this;
     }
     _logProcessedIssuesAndPullRequestsCount() {
         this._logGroup('Processed items', [
             {
                 name: 'Processed issues',
-                count: this._processedIssuesCount
+                count: this.processedIssuesCount
             },
             {
                 name: 'Processed PRs',
-                count: this._processedPullRequestsCount
+                count: this.processedPullRequestsCount
             }
         ]);
     }
@@ -1663,11 +1681,11 @@ class Statistics {
         this._logGroup('New stale items', [
             {
                 name: 'New stale issues',
-                count: this._staleIssuesCount
+                count: this.staleIssuesCount
             },
             {
                 name: 'New stale PRs',
-                count: this._stalePullRequestsCount
+                count: this.stalePullRequestsCount
             }
         ]);
     }
@@ -1675,11 +1693,11 @@ class Statistics {
         this._logGroup('No longer stale items', [
             {
                 name: 'No longer stale issues',
-                count: this._undoStaleIssuesCount
+                count: this.undoStaleIssuesCount
             },
             {
                 name: 'No longer stale PRs',
-                count: this._undoStalePullRequestsCount
+                count: this.undoStalePullRequestsCount
             }
         ]);
     }
@@ -1687,11 +1705,11 @@ class Statistics {
         this._logGroup('Closed items', [
             {
                 name: 'Closed issues',
-                count: this._closedIssuesCount
+                count: this.closedIssuesCount
             },
             {
                 name: 'Closed PRs',
-                count: this._closedPullRequestsCount
+                count: this.closedPullRequestsCount
             }
         ]);
     }
@@ -1699,11 +1717,11 @@ class Statistics {
         this._logGroup('Deleted items labels', [
             {
                 name: 'Deleted issues labels',
-                count: this._deletedIssuesLabelsCount
+                count: this.deletedIssuesLabelsCount
             },
             {
                 name: 'Deleted PRs labels',
-                count: this._deletedPullRequestsLabelsCount
+                count: this.deletedPullRequestsLabelsCount
             }
         ]);
     }
@@ -1711,26 +1729,26 @@ class Statistics {
         this._logGroup('Deleted close items labels', [
             {
                 name: 'Deleted close issues labels',
-                count: this._deletedCloseIssuesLabelsCount
+                count: this.deletedCloseIssuesLabelsCount
             },
             {
                 name: 'Deleted close PRs labels',
-                count: this._deletedClosePullRequestsLabelsCount
+                count: this.deletedClosePullRequestsLabelsCount
             }
         ]);
     }
     _logDeletedBranchesCount() {
-        this._logCount('Deleted branches', this._deletedBranchesCount);
+        this._logCount('Deleted branches', this.deletedBranchesCount);
     }
     _logAddedIssuesAndPullRequestsLabelsCount() {
         this._logGroup('Added items labels', [
             {
                 name: 'Added issues labels',
-                count: this._addedIssuesLabelsCount
+                count: this.addedIssuesLabelsCount
             },
             {
                 name: 'Added PRs labels',
-                count: this._addedPullRequestsLabelsCount
+                count: this.addedPullRequestsLabelsCount
             }
         ]);
     }
@@ -1738,28 +1756,28 @@ class Statistics {
         this._logGroup('Added items comments', [
             {
                 name: 'Added issues comments',
-                count: this._addedIssuesCommentsCount
+                count: this.addedIssuesCommentsCount
             },
             {
                 name: 'Added PRs comments',
-                count: this._addedPullRequestsCommentsCount
+                count: this.addedPullRequestsCommentsCount
             }
         ]);
     }
     _logFetchedItemsCount() {
-        this._logCount('Fetched items', this._fetchedItemsCount);
+        this._logCount('Fetched items', this.fetchedItemsCount);
     }
     _logFetchedItemsEventsCount() {
-        this._logCount('Fetched items events', this._fetchedItemsEventsCount);
+        this._logCount('Fetched items events', this.fetchedItemsEventsCount);
     }
     _logFetchedItemsCommentsCount() {
-        this._logCount('Fetched items comments', this._fetchedItemsCommentsCount);
+        this._logCount('Fetched items comments', this.fetchedItemsCommentsCount);
     }
     _logFetchedPullRequestsCount() {
-        this._logCount('Fetched pull requests', this._fetchedPullRequestsCount);
+        this._logCount('Fetched pull requests', this.fetchedPullRequestsCount);
     }
     _logOperationsCount() {
-        this._logCount('Operations performed', this._operationsCount);
+        this._logCount('Operations performed', this.operationsCount);
     }
     _logCount(name, count) {
         if (count > 0) {

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -69,6 +69,8 @@ export class IssuesProcessor {
   readonly deletedBranchIssues: Issue[] = [];
   readonly removedLabelIssues: Issue[] = [];
   readonly addedLabelIssues: Issue[] = [];
+  readonly addedStaleCommentIssues: Issue[] = [];
+  readonly addedCloseCommentIssues: Issue[] = [];
   private readonly _logger: Logger = new Logger();
   private readonly _statistics: Statistics | undefined;
 
@@ -772,6 +774,7 @@ export class IssuesProcessor {
       try {
         this._consumeIssueOperation(issue);
         this._statistics?.incrementAddedItemsComment(issue);
+        this.addedStaleCommentIssues.push(issue);
 
         if (!this.options.debugOnly) {
           await this.client.issues.createComment({
@@ -819,6 +822,7 @@ export class IssuesProcessor {
       try {
         this._consumeIssueOperation(issue);
         this._statistics?.incrementAddedItemsComment(issue);
+        this.addedCloseCommentIssues.push(issue);
 
         if (!this.options.debugOnly) {
           await this.client.issues.createComment({

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -872,7 +872,11 @@ export class IssuesProcessor {
   private async _deleteBranch(issue: Issue): Promise<void> {
     const issueLogger: IssueLogger = new IssueLogger(issue);
 
-    issueLogger.info(`Delete branch from closed $$type - ${issue.title}`);
+    issueLogger.info(`Delete
+    branch from closed $
+    $type
+    -
+    ${issue.title}`);
 
     const pullRequest: IPullRequest | undefined | void =
       await this.getPullRequest(issue);

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -70,8 +70,8 @@ export class IssuesProcessor {
   readonly removedLabelIssues: Issue[] = [];
   readonly addedLabelIssues: Issue[] = [];
   readonly addedCloseCommentIssues: Issue[] = [];
+  readonly statistics: Statistics | undefined;
   private readonly _logger: Logger = new Logger();
-  private readonly _statistics: Statistics | undefined;
 
   constructor(options: IIssuesProcessorOptions) {
     this.options = options;

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -599,7 +599,7 @@ export class IssuesProcessor {
 
     try {
       this._consumeIssueOperation(issue);
-      this._statistics?.incrementFetchedPullRequestsCount();
+      this.statistics?.incrementFetchedPullRequestsCount();
 
       const pullRequest = await this.client.pulls.get({
         owner: context.repo.owner,

--- a/src/classes/statistics.ts
+++ b/src/classes/statistics.ts
@@ -9,28 +9,28 @@ interface IGroupValue {
 
 export class Statistics {
   private readonly _logger: Logger = new Logger();
-  private _processedIssuesCount = 0;
-  private _processedPullRequestsCount = 0;
-  private _staleIssuesCount = 0;
-  private _stalePullRequestsCount = 0;
-  private _undoStaleIssuesCount = 0;
-  private _undoStalePullRequestsCount = 0;
-  private _operationsCount = 0;
-  private _closedIssuesCount = 0;
-  private _closedPullRequestsCount = 0;
-  private _deletedIssuesLabelsCount = 0;
-  private _deletedPullRequestsLabelsCount = 0;
-  private _deletedCloseIssuesLabelsCount = 0;
-  private _deletedClosePullRequestsLabelsCount = 0;
-  private _deletedBranchesCount = 0;
-  private _addedIssuesLabelsCount = 0;
-  private _addedPullRequestsLabelsCount = 0;
-  private _addedIssuesCommentsCount = 0;
-  private _addedPullRequestsCommentsCount = 0;
-  private _fetchedItemsCount = 0;
-  private _fetchedItemsEventsCount = 0;
-  private _fetchedItemsCommentsCount = 0;
-  private _fetchedPullRequestsCount = 0;
+  processedIssuesCount = 0;
+  processedPullRequestsCount = 0;
+  staleIssuesCount = 0;
+  stalePullRequestsCount = 0;
+  undoStaleIssuesCount = 0;
+  undoStalePullRequestsCount = 0;
+  operationsCount = 0;
+  closedIssuesCount = 0;
+  closedPullRequestsCount = 0;
+  deletedIssuesLabelsCount = 0;
+  deletedPullRequestsLabelsCount = 0;
+  deletedCloseIssuesLabelsCount = 0;
+  deletedClosePullRequestsLabelsCount = 0;
+  deletedBranchesCount = 0;
+  addedIssuesLabelsCount = 0;
+  addedPullRequestsLabelsCount = 0;
+  addedIssuesCommentsCount = 0;
+  addedPullRequestsCommentsCount = 0;
+  fetchedItemsCount = 0;
+  fetchedItemsEventsCount = 0;
+  fetchedItemsCommentsCount = 0;
+  fetchedPullRequestsCount = 0;
 
   incrementProcessedItemsCount(
     issue: Readonly<Issue>,
@@ -66,7 +66,7 @@ export class Statistics {
   }
 
   setOperationsCount(operationsCount: Readonly<number>): Statistics {
-    this._operationsCount = operationsCount;
+    this.operationsCount = operationsCount;
 
     return this;
   }
@@ -105,7 +105,7 @@ export class Statistics {
   }
 
   incrementDeletedBranchesCount(increment: Readonly<number> = 1): Statistics {
-    this._deletedBranchesCount += increment;
+    this.deletedBranchesCount += increment;
 
     return this;
   }
@@ -133,7 +133,7 @@ export class Statistics {
   }
 
   incrementFetchedItemsCount(increment: Readonly<number> = 1): Statistics {
-    this._fetchedItemsCount += increment;
+    this.fetchedItemsCount += increment;
 
     return this;
   }
@@ -141,7 +141,7 @@ export class Statistics {
   incrementFetchedItemsEventsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._fetchedItemsEventsCount += increment;
+    this.fetchedItemsEventsCount += increment;
 
     return this;
   }
@@ -149,7 +149,7 @@ export class Statistics {
   incrementFetchedItemsCommentsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._fetchedItemsCommentsCount += increment;
+    this.fetchedItemsCommentsCount += increment;
 
     return this;
   }
@@ -157,7 +157,7 @@ export class Statistics {
   incrementFetchedPullRequestsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._fetchedPullRequestsCount += increment;
+    this.fetchedPullRequestsCount += increment;
 
     return this;
   }
@@ -185,7 +185,7 @@ export class Statistics {
   private _incrementProcessedIssuesCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._processedIssuesCount += increment;
+    this.processedIssuesCount += increment;
 
     return this;
   }
@@ -193,7 +193,7 @@ export class Statistics {
   private _incrementProcessedPullRequestsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._processedPullRequestsCount += increment;
+    this.processedPullRequestsCount += increment;
 
     return this;
   }
@@ -201,7 +201,7 @@ export class Statistics {
   private _incrementStaleIssuesCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._staleIssuesCount += increment;
+    this.staleIssuesCount += increment;
 
     return this;
   }
@@ -209,7 +209,7 @@ export class Statistics {
   private _incrementStalePullRequestsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._stalePullRequestsCount += increment;
+    this.stalePullRequestsCount += increment;
 
     return this;
   }
@@ -217,7 +217,7 @@ export class Statistics {
   private _incrementUndoStaleIssuesCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._undoStaleIssuesCount += increment;
+    this.undoStaleIssuesCount += increment;
 
     return this;
   }
@@ -225,7 +225,7 @@ export class Statistics {
   private _incrementUndoStalePullRequestsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._undoStalePullRequestsCount += increment;
+    this.undoStalePullRequestsCount += increment;
 
     return this;
   }
@@ -233,7 +233,7 @@ export class Statistics {
   private _incrementClosedIssuesCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._closedIssuesCount += increment;
+    this.closedIssuesCount += increment;
 
     return this;
   }
@@ -241,7 +241,7 @@ export class Statistics {
   private _incrementClosedPullRequestsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._closedPullRequestsCount += increment;
+    this.closedPullRequestsCount += increment;
 
     return this;
   }
@@ -249,7 +249,7 @@ export class Statistics {
   private _incrementDeletedIssuesLabelsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._deletedIssuesLabelsCount += increment;
+    this.deletedIssuesLabelsCount += increment;
 
     return this;
   }
@@ -257,7 +257,7 @@ export class Statistics {
   private _incrementDeletedPullRequestsLabelsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._deletedPullRequestsLabelsCount += increment;
+    this.deletedPullRequestsLabelsCount += increment;
 
     return this;
   }
@@ -265,7 +265,7 @@ export class Statistics {
   private _incrementDeletedCloseIssuesLabelsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._deletedCloseIssuesLabelsCount += increment;
+    this.deletedCloseIssuesLabelsCount += increment;
 
     return this;
   }
@@ -273,7 +273,7 @@ export class Statistics {
   private _incrementDeletedClosePullRequestsLabelsCount(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._deletedClosePullRequestsLabelsCount += increment;
+    this.deletedClosePullRequestsLabelsCount += increment;
 
     return this;
   }
@@ -281,7 +281,7 @@ export class Statistics {
   private _incrementAddedIssuesLabel(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._addedIssuesLabelsCount += increment;
+    this.addedIssuesLabelsCount += increment;
 
     return this;
   }
@@ -289,7 +289,7 @@ export class Statistics {
   private _incrementAddedPullRequestsLabel(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._addedPullRequestsLabelsCount += increment;
+    this.addedPullRequestsLabelsCount += increment;
 
     return this;
   }
@@ -297,7 +297,7 @@ export class Statistics {
   private _incrementAddedIssuesComment(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._addedIssuesCommentsCount += increment;
+    this.addedIssuesCommentsCount += increment;
 
     return this;
   }
@@ -305,7 +305,7 @@ export class Statistics {
   private _incrementAddedPullRequestsComment(
     increment: Readonly<number> = 1
   ): Statistics {
-    this._addedPullRequestsCommentsCount += increment;
+    this.addedPullRequestsCommentsCount += increment;
 
     return this;
   }
@@ -314,11 +314,11 @@ export class Statistics {
     this._logGroup('Processed items', [
       {
         name: 'Processed issues',
-        count: this._processedIssuesCount
+        count: this.processedIssuesCount
       },
       {
         name: 'Processed PRs',
-        count: this._processedPullRequestsCount
+        count: this.processedPullRequestsCount
       }
     ]);
   }
@@ -327,11 +327,11 @@ export class Statistics {
     this._logGroup('New stale items', [
       {
         name: 'New stale issues',
-        count: this._staleIssuesCount
+        count: this.staleIssuesCount
       },
       {
         name: 'New stale PRs',
-        count: this._stalePullRequestsCount
+        count: this.stalePullRequestsCount
       }
     ]);
   }
@@ -340,11 +340,11 @@ export class Statistics {
     this._logGroup('No longer stale items', [
       {
         name: 'No longer stale issues',
-        count: this._undoStaleIssuesCount
+        count: this.undoStaleIssuesCount
       },
       {
         name: 'No longer stale PRs',
-        count: this._undoStalePullRequestsCount
+        count: this.undoStalePullRequestsCount
       }
     ]);
   }
@@ -353,11 +353,11 @@ export class Statistics {
     this._logGroup('Closed items', [
       {
         name: 'Closed issues',
-        count: this._closedIssuesCount
+        count: this.closedIssuesCount
       },
       {
         name: 'Closed PRs',
-        count: this._closedPullRequestsCount
+        count: this.closedPullRequestsCount
       }
     ]);
   }
@@ -366,11 +366,11 @@ export class Statistics {
     this._logGroup('Deleted items labels', [
       {
         name: 'Deleted issues labels',
-        count: this._deletedIssuesLabelsCount
+        count: this.deletedIssuesLabelsCount
       },
       {
         name: 'Deleted PRs labels',
-        count: this._deletedPullRequestsLabelsCount
+        count: this.deletedPullRequestsLabelsCount
       }
     ]);
   }
@@ -379,28 +379,28 @@ export class Statistics {
     this._logGroup('Deleted close items labels', [
       {
         name: 'Deleted close issues labels',
-        count: this._deletedCloseIssuesLabelsCount
+        count: this.deletedCloseIssuesLabelsCount
       },
       {
         name: 'Deleted close PRs labels',
-        count: this._deletedClosePullRequestsLabelsCount
+        count: this.deletedClosePullRequestsLabelsCount
       }
     ]);
   }
 
   private _logDeletedBranchesCount(): void {
-    this._logCount('Deleted branches', this._deletedBranchesCount);
+    this._logCount('Deleted branches', this.deletedBranchesCount);
   }
 
   private _logAddedIssuesAndPullRequestsLabelsCount(): void {
     this._logGroup('Added items labels', [
       {
         name: 'Added issues labels',
-        count: this._addedIssuesLabelsCount
+        count: this.addedIssuesLabelsCount
       },
       {
         name: 'Added PRs labels',
-        count: this._addedPullRequestsLabelsCount
+        count: this.addedPullRequestsLabelsCount
       }
     ]);
   }
@@ -409,33 +409,33 @@ export class Statistics {
     this._logGroup('Added items comments', [
       {
         name: 'Added issues comments',
-        count: this._addedIssuesCommentsCount
+        count: this.addedIssuesCommentsCount
       },
       {
         name: 'Added PRs comments',
-        count: this._addedPullRequestsCommentsCount
+        count: this.addedPullRequestsCommentsCount
       }
     ]);
   }
 
   private _logFetchedItemsCount(): void {
-    this._logCount('Fetched items', this._fetchedItemsCount);
+    this._logCount('Fetched items', this.fetchedItemsCount);
   }
 
   private _logFetchedItemsEventsCount(): void {
-    this._logCount('Fetched items events', this._fetchedItemsEventsCount);
+    this._logCount('Fetched items events', this.fetchedItemsEventsCount);
   }
 
   private _logFetchedItemsCommentsCount(): void {
-    this._logCount('Fetched items comments', this._fetchedItemsCommentsCount);
+    this._logCount('Fetched items comments', this.fetchedItemsCommentsCount);
   }
 
   private _logFetchedPullRequestsCount(): void {
-    this._logCount('Fetched pull requests', this._fetchedPullRequestsCount);
+    this._logCount('Fetched pull requests', this.fetchedPullRequestsCount);
   }
 
   private _logOperationsCount(): void {
-    this._logCount('Operations performed', this._operationsCount);
+    this._logCount('Operations performed', this.operationsCount);
   }
 
   private _logCount(name: Readonly<string>, count: Readonly<number>): void {


### PR DESCRIPTION
## Changes

- [x] Update the doc to mention that a message will be sent with the default workflow
- [x] Update the doc to remove the part that say that the stale issue message will not be sent when omitted (since the code is checking for empty string and there is a default value, a comment should be added for issue and PRs due to this default value)
- [x] Add a test to confirm this

Closes #521
