### PR TITLE
docs(readme): fix a wrong ISO format date example

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          start-date: '2020-18-04T00:00:00Z' # ISO 8601 or RFC 2822
+          start-date: '2020-04-18T00:00:00Z' # ISO 8601 or RFC 2822
 ```
 
 Avoid stale for specific milestones:


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes

- [x] Updates start-date format on README usage example

## Context

<!-- Explain why you're making the change(s). -->
<!-- If you're closing an issue with this PR, [link them with a keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->

Closes #561 . Just prevents quick copy-paste from anyone not double checking and accidentally setting the wrong start date.
