### PR TITLE
Fix per issue operation count

### DIFF
--- a/__tests__/classes/issues-processor-mock.ts
+++ b/__tests__/classes/issues-processor-mock.ts
@@ -9,7 +9,7 @@ export class IssuesProcessorMock extends IssuesProcessor {
     options: IIssuesProcessorOptions,
     getIssues?: (page: number) => Promise<Issue[]>,
     listIssueComments?: (
-      issueNumber: number,
+      issue: Issue,
       sinceDate: string
     ) => Promise<IComment[]>,
     getLabelCreationDate?: (

--- a/dist/index.js
+++ b/dist/index.js
@@ -613,17 +613,17 @@ class IssuesProcessor {
         });
     }
     // Grab comments for an issue since a given date
-    listIssueComments(issueNumber, sinceDate) {
+    listIssueComments(issue, sinceDate) {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
             // Find any comments since date on the given issue
             try {
-                this.operations.consumeOperation();
+                this._consumeIssueOperation(issue);
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCommentsCount();
                 const comments = yield this.client.issues.listComments({
                     owner: github_1.context.repo.owner,
                     repo: github_1.context.repo.repo,
-                    issue_number: issueNumber,
+                    issue_number: issue.number,
                     since: sinceDate
                 });
                 return comments.data;
@@ -763,7 +763,7 @@ class IssuesProcessor {
                 return true;
             }
             // find any comments since the date
-            const comments = yield this.listIssueComments(issue.number, sinceDate);
+            const comments = yield this.listIssueComments(issue, sinceDate);
             const filteredComments = comments.filter(comment => comment.user.type === 'User' &&
                 comment.body.toLowerCase() !== staleMessage.toLowerCase());
             issueLogger.info(`Comments that are not the stale comment or another bot: ${logger_service_1.LoggerService.cyan(filteredComments.length)}`);
@@ -1014,7 +1014,7 @@ class IssuesProcessor {
             issueLogger.info(`Adding all the labels specified via the ${this._logger.createOptionLink(option_1.Option.LabelsToAddWhenUnstale)} option.`);
             this.addedLabelIssues.push(issue);
             try {
-                this.operations.consumeOperation();
+                this._consumeIssueOperation(issue);
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementAddedItemsLabel(issue);
                 if (!this.options.debugOnly) {
                     yield this.client.issues.addLabels({

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -510,17 +510,17 @@ export class IssuesProcessor {
 
   // Grab comments for an issue since a given date
   async listIssueComments(
-    issueNumber: Readonly<number>,
+    issue: Readonly<Issue>,
     sinceDate: Readonly<string>
   ): Promise<IComment[]> {
     // Find any comments since date on the given issue
     try {
-      this.operations.consumeOperation();
+      this._consumeIssueOperation(issue);
       this.statistics?.incrementFetchedItemsCommentsCount();
       const comments = await this.client.issues.listComments({
         owner: context.repo.owner,
         repo: context.repo.repo,
-        issue_number: issueNumber,
+        issue_number: issue.number,
         since: sinceDate
       });
       return comments.data;
@@ -734,7 +734,7 @@ export class IssuesProcessor {
     }
 
     // find any comments since the date
-    const comments = await this.listIssueComments(issue.number, sinceDate);
+    const comments = await this.listIssueComments(issue, sinceDate);
 
     const filteredComments = comments.filter(
       comment =>
@@ -1065,7 +1065,7 @@ export class IssuesProcessor {
     this.addedLabelIssues.push(issue);
 
     try {
-      this.operations.consumeOperation();
+      this._consumeIssueOperation(issue);
       this.statistics?.incrementAddedItemsLabel(issue);
       if (!this.options.debugOnly) {
         await this.client.issues.addLabels({


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes

- [x] Fixes an issue where per-issue operation count could be inaccurate in some cases

## Context
fixes https://github.com/actions/stale/issues/661

I wanted to add some unit tests and fix the problem TDD-style, but this proved to be tough given the way that `issues-processor` is currently mocked out, so I gave up. Related, I also think that some of the tests in `https://github.com/actions/stale/blob/main/__tests__/operations-per-run.spec.ts` are making incorrect assertions because some of the methods that increment operation count get mocked. This all seems pretty fixable, but I think that would require more churn than I'm comfortable introducing right now, so if tests are required for this PR I think I'll leave it to someone else.