### PR TITLE
Don't process a stale issue in the same run it's marked stale

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -278,6 +278,7 @@ class Issue {
         this.milestone = issue.milestone;
         this.assignees = issue.assignees;
         this.isStale = is_labeled_1.isLabeled(this, this.staleLabel);
+        this.markedStaleThisRun = false;
     }
     get isPullRequest() {
         return is_pull_request_1.isPullRequest(this);
@@ -589,6 +590,7 @@ class IssuesProcessor {
                         issueLogger.info(`This $$type should be marked as stale based on the option ${issueLogger.createOptionLink(this._getDaysBeforeStaleUsedOptionName(issue))} (${logger_service_1.LoggerService.cyan(daysBeforeStale)})`);
                         yield this._markStale(issue, staleMessage, staleLabel, skipMessage);
                         issue.isStale = true; // This issue is now considered stale
+                        issue.markedStaleThisRun = true;
                         issueLogger.info(`This $$type is now stale`);
                     }
                     else {
@@ -726,8 +728,13 @@ class IssuesProcessor {
             else {
                 issueLogger.info(`The stale label should be removed if all conditions met`);
             }
+            if (issue.markedStaleThisRun) {
+                issueLogger.info(`marked stale this run, so don't check for updates`);
+            }
             // Should we un-stale this issue?
-            if (shouldRemoveStaleWhenUpdated && issueHasComments) {
+            if (shouldRemoveStaleWhenUpdated &&
+                issueHasComments &&
+                !issue.markedStaleThisRun) {
                 issueLogger.info(`Remove the stale label since the $$type has a comment and the workflow should remove the stale label when updated`);
                 yield this._removeStaleLabel(issue, staleLabel);
                 // Are there labels to remove or add when an issue is no longer stale?

--- a/src/classes/issue.ts
+++ b/src/classes/issue.ts
@@ -20,6 +20,7 @@ export class Issue implements IIssue {
   readonly milestone: IMilestone | undefined;
   readonly assignees: Assignee[];
   isStale: boolean;
+  markedStaleThisRun: boolean;
   operations = new Operations();
   private readonly _options: IIssuesProcessorOptions;
 
@@ -39,6 +40,7 @@ export class Issue implements IIssue {
     this.milestone = issue.milestone;
     this.assignees = issue.assignees;
     this.isStale = isLabeled(this, this.staleLabel);
+    this.markedStaleThisRun = false;
   }
 
   get isPullRequest(): boolean {

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -466,6 +466,7 @@ export class IssuesProcessor {
           );
           await this._markStale(issue, staleMessage, staleLabel, skipMessage);
           issue.isStale = true; // This issue is now considered stale
+          issue.markedStaleThisRun = true;
           issueLogger.info(`This $$type is now stale`);
         } else {
           issueLogger.info(
@@ -672,8 +673,16 @@ export class IssuesProcessor {
       );
     }
 
+    if (issue.markedStaleThisRun) {
+      issueLogger.info(`marked stale this run, so don't check for updates`);
+    }
+
     // Should we un-stale this issue?
-    if (shouldRemoveStaleWhenUpdated && issueHasComments) {
+    if (
+      shouldRemoveStaleWhenUpdated &&
+      issueHasComments &&
+      !issue.markedStaleThisRun
+    ) {
       issueLogger.info(
         `Remove the stale label since the $$type has a comment and the workflow should remove the stale label when updated`
       );


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes
We don't want to check for comments/updates if the issue/PR was just marked stale that run. 

- [x] ...

## Context
fixes #690 
<!-- Explain why you're making the change(s). -->
<!-- If you're closing an issue with this PR, [link them with a keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->
