### PR TITLE
[Bugfix] Remove stale when updated without comment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -741,9 +741,9 @@ class IssuesProcessor {
             }
             // Should we un-stale this issue?
             if (shouldRemoveStaleWhenUpdated &&
-                issueHasComments &&
+                (issueHasUpdate || issueHasComments) &&
                 !issue.markedStaleThisRun) {
-                issueLogger.info(`Remove the stale label since the $$type has a comment and the workflow should remove the stale label when updated`);
+                issueLogger.info(`Remove the stale label since the $$type has been updated and the workflow should remove the stale label when updated`);
                 yield this._removeStaleLabel(issue, staleLabel);
                 // Are there labels to remove or add when an issue is no longer stale?
                 yield this._removeLabelsWhenUnstale(issue, labelsToRemoveWhenUnstale);

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -674,11 +674,11 @@ export class IssuesProcessor {
     // Should we un-stale this issue?
     if (
       shouldRemoveStaleWhenUpdated &&
-      issueHasComments &&
+      (issueHasUpdate || issueHasComments) &&
       !issue.markedStaleThisRun
     ) {
       issueLogger.info(
-        `Remove the stale label since the $$type has a comment and the workflow should remove the stale label when updated`
+        `Remove the stale label since the $$type has been updated and the workflow should remove the stale label when updated`
       );
       await this._removeStaleLabel(issue, staleLabel);
 


### PR DESCRIPTION
The existing logic for `remove-stale-when-updated` only considers presence of comments, ignoring the presence of any other kind of  update.

This fixes it so it follows the documented behaviour for that setting.

There is no effect from this change on tests (all pass). I suspect that the tests simply do not cover the case of updates, only comments; the new logic is equivalent to the old one for the case of new comments.
I would have included new tests to add to the coverage, but I have no idea how to achieve that as this is my first time ever touching TypeScript code.

## Changes

- [x] The check for removing stale now takes into account the value of `issueHasUpdate`

## Context

Fixes #715
