### PR TITLE
Change NPM version update interval (daily → weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates once a week (Monday)
     schedule:
-      interval: 'daily'
+      interval: 'weekly'


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes

- [x] Dependabot will check for NPM version updates weekly instead of daily

## Context

<!-- Explain why you're making the change(s). -->
<!-- If you're closing an issue with this PR, [link them with a keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->

Checking daily results in a lot of closed PRs because new PRs supersede them before they are reviewed and merged.