### PR TITLE
Add close-issue-reason option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Every argument is optional.
 | [close-pr-message](#close-pr-message)                               | Comment on the staled PRs while closed                                      |                       |
 | [stale-issue-label](#stale-issue-label)                             | Label to apply on staled issues                                             | `Stale`               |
 | [close-issue-label](#close-issue-label)                             | Label to apply on closed issues                                             |                       |
+| [close-issue-reason](#close-issue-reason)                           | Reason to use when closing issues                                           |                       |
 | [stale-pr-label](#stale-pr-label)                                   | Label to apply on staled PRs                                                | `Stale`               |
 | [close-pr-label](#close-pr-label)                                   | Label to apply on closed PRs                                                |                       |
 | [exempt-issue-labels](#exempt-issue-labels)                         | Labels on issues exempted from stale                                        |                       |
@@ -80,7 +81,6 @@ Every argument is optional.
 | [ignore-updates](#ignore-updates)                                   | Any update (update/comment) can reset the stale idle time on the issues/PRs | `false`               |
 | [ignore-issue-updates](#ignore-issue-updates)                       | Override [ignore-updates](#ignore-updates) for issues only                  |                       |
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
-| [close-as-not-planned](#close-as-not-planned)                       | Close issues as "not planned" instead of "completed"                        |                       |
 
 ### List of output options
 
@@ -510,9 +510,9 @@ Useful to override [ignore-updates](#ignore-updates) but only to ignore the upda
 
 Default value: unset
 
-#### close-as-not-planned
+#### close-issue-reason
 
-When closing issues, close them as ["not planned"](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/) instead of "completed".
+Specify the [reason](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/) used when closing issues. Valid values are `completed` and `not_planned`.
 
 Default value: unset
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Every argument is optional.
 | [ignore-updates](#ignore-updates)                                   | Any update (update/comment) can reset the stale idle time on the issues/PRs | `false`               |
 | [ignore-issue-updates](#ignore-issue-updates)                       | Override [ignore-updates](#ignore-updates) for issues only                  |                       |
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
+| [close-as-not-planned](#close-as-not-planned)                       | Use the "not planned" close reason for issues                               |                       |
 
 ### List of output options
 
@@ -506,6 +507,12 @@ Default value: unset
 #### ignore-pr-updates
 
 Useful to override [ignore-updates](#ignore-updates) but only to ignore the updates for the pull requests.
+
+Default value: unset
+
+#### close-as-not-planned
+
+When closing issues, close them as ["not planned"](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/).
 
 Default value: unset
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ It will be automatically removed if the issues are no longer closed nor locked.
 Default value: unset  
 Required Permission: `issues: write`
 
+#### close-issue-reason
+
+Specify the [reason](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/) used when closing issues. Valid values are `completed` and `not_planned`.
+
+Default value: unset
+
 #### stale-pr-label
 
 The label that will be added to the pull requests when automatically marked as stale.  
@@ -507,12 +513,6 @@ Default value: unset
 #### ignore-pr-updates
 
 Useful to override [ignore-updates](#ignore-updates) but only to ignore the updates for the pull requests.
-
-Default value: unset
-
-#### close-issue-reason
-
-Specify the [reason](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/) used when closing issues. Valid values are `completed` and `not_planned`.
 
 Default value: unset
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Every argument is optional.
 | [ignore-updates](#ignore-updates)                                   | Any update (update/comment) can reset the stale idle time on the issues/PRs | `false`               |
 | [ignore-issue-updates](#ignore-issue-updates)                       | Override [ignore-updates](#ignore-updates) for issues only                  |                       |
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
-| [close-as-not-planned](#close-as-not-planned)                       | Use the "not planned" close reason for issues                               |                       |
+| [close-as-not-planned](#close-as-not-planned)                       | Close issues as "not planned" instead of "completed"                        |                       |
 
 ### List of output options
 
@@ -512,7 +512,7 @@ Default value: unset
 
 #### close-as-not-planned
 
-When closing issues, close them as ["not planned"](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/).
+When closing issues, close them as ["not planned"](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/) instead of "completed".
 
 Default value: unset
 

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -51,5 +51,5 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   ignoreIssueUpdates: undefined,
   ignorePrUpdates: undefined,
   exemptDraftPr: false,
-  closeAsNotPlanned: undefined
+  closeIssueReason: undefined
 });

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -50,5 +50,6 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   ignoreUpdates: false,
   ignoreIssueUpdates: undefined,
   ignorePrUpdates: undefined,
-  exemptDraftPr: false
+  exemptDraftPr: false,
+  closeAsNotPlanned: undefined
 });

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -51,5 +51,5 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   ignoreIssueUpdates: undefined,
   ignorePrUpdates: undefined,
   exemptDraftPr: false,
-  closeIssueReason: undefined
+  closeIssueReason: ''
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -885,7 +885,10 @@ class IssuesProcessor {
                         owner: github_1.context.repo.owner,
                         repo: github_1.context.repo.repo,
                         issue_number: issue.number,
-                        state: 'closed'
+                        state: 'closed',
+                        state_reason: this.options.closeAsNotPlanned
+                            ? 'not_planned'
+                            : undefined
                     });
                 }
             }
@@ -1892,6 +1895,7 @@ var Option;
     Option["IgnoreIssueUpdates"] = "ignore-issue-updates";
     Option["IgnorePrUpdates"] = "ignore-pr-updates";
     Option["ExemptDraftPr"] = "exempt-draft-pr";
+    Option["CloseAsNotPlanned"] = "close-as-not-planned";
 })(Option = exports.Option || (exports.Option = {}));
 
 
@@ -2202,7 +2206,8 @@ function _getAndValidateArgs() {
         ignoreUpdates: core.getInput('ignore-updates') === 'true',
         ignoreIssueUpdates: _toOptionalBoolean('ignore-issue-updates'),
         ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
-        exemptDraftPr: core.getInput('exempt-draft-pr') === 'true'
+        exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
+        closeAsNotPlanned: _toOptionalBoolean('close-as-not-planned')
     };
     for (const numberInput of [
         'days-before-stale',

--- a/dist/index.js
+++ b/dist/index.js
@@ -886,9 +886,7 @@ class IssuesProcessor {
                         repo: github_1.context.repo.repo,
                         issue_number: issue.number,
                         state: 'closed',
-                        state_reason: this.options.closeAsNotPlanned
-                            ? 'not_planned'
-                            : undefined
+                        state_reason: this.options.closeIssueReason || undefined
                     });
                 }
             }
@@ -1895,7 +1893,7 @@ var Option;
     Option["IgnoreIssueUpdates"] = "ignore-issue-updates";
     Option["IgnorePrUpdates"] = "ignore-pr-updates";
     Option["ExemptDraftPr"] = "exempt-draft-pr";
-    Option["CloseAsNotPlanned"] = "close-as-not-planned";
+    Option["CloseIssueReason"] = "close-issue-reason";
 })(Option = exports.Option || (exports.Option = {}));
 
 
@@ -2207,7 +2205,7 @@ function _getAndValidateArgs() {
         ignoreIssueUpdates: _toOptionalBoolean('ignore-issue-updates'),
         ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
         exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
-        closeAsNotPlanned: _toOptionalBoolean('close-as-not-planned')
+        closeIssueReason: core.getInput('close-issue-reason')
     };
     for (const numberInput of [
         'days-before-stale',
@@ -2229,6 +2227,11 @@ function _getAndValidateArgs() {
                 throw new Error(errorMessage);
             }
         }
+    }
+    if (![undefined, 'completed', 'not_planned'].includes(args.closeIssueReason)) {
+        const errorMessage = `Unrecognized close-issue-reason "${args.closeIssueReason}"`;
+        core.setFailed(errorMessage);
+        throw new Error(errorMessage);
     }
     return args;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2228,8 +2228,9 @@ function _getAndValidateArgs() {
             }
         }
     }
-    if (![undefined, 'completed', 'not_planned'].includes(args.closeIssueReason)) {
-        const errorMessage = `Unrecognized close-issue-reason "${args.closeIssueReason}"`;
+    const validCloseReasons = ['', 'completed', 'not_planned'];
+    if (!validCloseReasons.includes(args.closeIssueReason)) {
+        const errorMessage = `Unrecognized close-issue-reason "${args.closeIssueReason}", valid values are: ${validCloseReasons.filter(Boolean).join(', ')}`;
         core.setFailed(errorMessage);
         throw new Error(errorMessage);
     }

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -61,7 +61,8 @@ describe('Issue', (): void => {
       ignoreUpdates: false,
       ignoreIssueUpdates: undefined,
       ignorePrUpdates: undefined,
-      exemptDraftPr: false
+      exemptDraftPr: false,
+      closeAsNotPlanned: undefined
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -62,7 +62,7 @@ describe('Issue', (): void => {
       ignoreIssueUpdates: undefined,
       ignorePrUpdates: undefined,
       exemptDraftPr: false,
-      closeIssueReason: undefined
+      closeIssueReason: ''
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -62,7 +62,7 @@ describe('Issue', (): void => {
       ignoreIssueUpdates: undefined,
       ignorePrUpdates: undefined,
       exemptDraftPr: false,
-      closeAsNotPlanned: undefined
+      closeIssueReason: undefined
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -866,9 +866,7 @@ export class IssuesProcessor {
           repo: context.repo.repo,
           issue_number: issue.number,
           state: 'closed',
-          state_reason: this.options.closeAsNotPlanned
-            ? 'not_planned'
-            : undefined
+          state_reason: this.options.closeIssueReason || undefined
         });
       }
     } catch (error) {

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -865,7 +865,10 @@ export class IssuesProcessor {
           owner: context.repo.owner,
           repo: context.repo.repo,
           issue_number: issue.number,
-          state: 'closed'
+          state: 'closed',
+          state_reason: this.options.closeAsNotPlanned
+            ? 'not_planned'
+            : undefined
         });
       }
     } catch (error) {

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -46,5 +46,6 @@ export enum Option {
   IgnoreUpdates = 'ignore-updates',
   IgnoreIssueUpdates = 'ignore-issue-updates',
   IgnorePrUpdates = 'ignore-pr-updates',
-  ExemptDraftPr = 'exempt-draft-pr'
+  ExemptDraftPr = 'exempt-draft-pr',
+  CloseAsNotPlanned = 'close-as-not-planned'
 }

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -47,5 +47,5 @@ export enum Option {
   IgnoreIssueUpdates = 'ignore-issue-updates',
   IgnorePrUpdates = 'ignore-pr-updates',
   ExemptDraftPr = 'exempt-draft-pr',
-  CloseAsNotPlanned = 'close-as-not-planned'
+  CloseIssueReason = 'close-issue-reason'
 }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -51,5 +51,5 @@ export interface IIssuesProcessorOptions {
   ignoreIssueUpdates: boolean | undefined;
   ignorePrUpdates: boolean | undefined;
   exemptDraftPr: boolean;
-  closeIssueReason: string | undefined;
+  closeIssueReason: string;
 }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -51,5 +51,5 @@ export interface IIssuesProcessorOptions {
   ignoreIssueUpdates: boolean | undefined;
   ignorePrUpdates: boolean | undefined;
   exemptDraftPr: boolean;
-  closeAsNotPlanned: boolean | undefined;
+  closeIssueReason: string | undefined;
 }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -51,4 +51,5 @@ export interface IIssuesProcessorOptions {
   ignoreIssueUpdates: boolean | undefined;
   ignorePrUpdates: boolean | undefined;
   exemptDraftPr: boolean;
+  closeAsNotPlanned: boolean | undefined;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,7 +87,8 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ignoreUpdates: core.getInput('ignore-updates') === 'true',
     ignoreIssueUpdates: _toOptionalBoolean('ignore-issue-updates'),
     ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
-    exemptDraftPr: core.getInput('exempt-draft-pr') === 'true'
+    exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
+    closeAsNotPlanned: _toOptionalBoolean('close-as-not-planned')
   };
 
   for (const numberInput of [

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,7 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ignoreIssueUpdates: _toOptionalBoolean('ignore-issue-updates'),
     ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
     exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
-    closeAsNotPlanned: _toOptionalBoolean('close-as-not-planned')
+    closeIssueReason: core.getInput('close-issue-reason')
   };
 
   for (const numberInput of [
@@ -112,6 +112,14 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
         throw new Error(errorMessage);
       }
     }
+  }
+
+  if (
+    ![undefined, 'completed', 'not_planned'].includes(args.closeIssueReason)
+  ) {
+    const errorMessage = `Unrecognized close-issue-reason "${args.closeIssueReason}"`;
+    core.setFailed(errorMessage);
+    throw new Error(errorMessage);
   }
 
   return args;

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,10 +114,11 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     }
   }
 
-  if (
-    ![undefined, 'completed', 'not_planned'].includes(args.closeIssueReason)
-  ) {
-    const errorMessage = `Unrecognized close-issue-reason "${args.closeIssueReason}"`;
+  const validCloseReasons = ['', 'completed', 'not_planned'];
+  if (!validCloseReasons.includes(args.closeIssueReason)) {
+    const errorMessage = `Unrecognized close-issue-reason "${
+      args.closeIssueReason
+    }", valid values are: ${validCloseReasons.filter(Boolean).join(', ')}`;
     core.setFailed(errorMessage);
     throw new Error(errorMessage);
   }


### PR DESCRIPTION
## Changes

Adds an option `close-issue-reason`, which can be used to close stale issues as ["not planned"](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/) (a relatively new GitHub feature).

I tested the `state_reason: "not_planned"` option by making manual calls to the REST API (unfortunately it is not currently listed in the REST API documentation).

## Context

Resolves https://github.com/actions/stale/issues/744