### PR TITLE
fix(options): add missing `close-issue-reason` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: 'The labels that mean an issue is exempt from being marked stale. Separate multiple labels with commas (eg. "label1,label2").'
     default: ''
     required: false
+  close-issue-reason:
+    description: 'The reason to use when closing an issue.'
+    default: ''
+    required: false
   stale-pr-label:
     description: 'The label to apply when a pull request is stale.'
     default: 'Stale'


### PR DESCRIPTION
## Changes

Add the missing `close-issue-reason` option to the `action.yml`

## Context

It's great that #764 has added the `close-issue-reason` option to allow closing a stale issue with a specified reason. But it seems this new option is missing in the `action.yml` configuration file, so a warning will be generated when running the action and the stale issues can't be closed with the expected reason.

![image](https://user-images.githubusercontent.com/26999792/177484604-e4596cba-36d4-448c-a37a-e6d633e6e2b6.png)

Please refer to the following action for more details: https://github.com/apache/echarts/actions/runs/2618863511

---

Oh... I'm sorry I just found the feature hasn't been released. Perhaps, can we publish a new version for it?