### PR TITLE
Fix issue when days-before-close is more than days-before-stale

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -720,14 +720,12 @@ class IssuesProcessor {
             const issueLogger = new issue_logger_1.IssueLogger(issue);
             const markedStaleOn = (yield this.getLabelCreationDate(issue, staleLabel)) || issue.updated_at;
             issueLogger.info(`$$type marked stale on: ${logger_service_1.LoggerService.cyan(markedStaleOn)}`);
-            const issueHasComments = yield this._hasCommentsSince(issue, markedStaleOn, staleMessage);
-            issueLogger.info(`$$type has been commented on: ${logger_service_1.LoggerService.cyan(issueHasComments)}`);
+            const issueHasCommentsSinceStale = yield this._hasCommentsSince(issue, markedStaleOn, staleMessage);
+            issueLogger.info(`$$type has been commented on: ${logger_service_1.LoggerService.cyan(issueHasCommentsSinceStale)}`);
             const daysBeforeClose = issue.isPullRequest
                 ? this._getDaysBeforePrClose()
                 : this._getDaysBeforeIssueClose();
             issueLogger.info(`Days before $$type close: ${logger_service_1.LoggerService.cyan(daysBeforeClose)}`);
-            const issueHasUpdate = IssuesProcessor._updatedSince(issue.updated_at, daysBeforeClose);
-            issueLogger.info(`$$type has been updated: ${logger_service_1.LoggerService.cyan(issueHasUpdate)}`);
             const shouldRemoveStaleWhenUpdated = this._shouldRemoveStaleWhenUpdated(issue);
             issueLogger.info(`The option ${issueLogger.createOptionLink(this._getRemoveStaleWhenUpdatedUsedOptionName(issue))} is: ${logger_service_1.LoggerService.cyan(shouldRemoveStaleWhenUpdated)}`);
             if (shouldRemoveStaleWhenUpdated) {
@@ -739,9 +737,11 @@ class IssuesProcessor {
             if (issue.markedStaleThisRun) {
                 issueLogger.info(`marked stale this run, so don't check for updates`);
             }
+            const issueHasUpdateSinceStale = new Date(issue.updated_at) > new Date(markedStaleOn);
+            issueLogger.info(`$$type has been updated since it was marked stale: ${logger_service_1.LoggerService.cyan(issueHasUpdateSinceStale)}`);
             // Should we un-stale this issue?
             if (shouldRemoveStaleWhenUpdated &&
-                (issueHasUpdate || issueHasComments) &&
+                (issueHasUpdateSinceStale || issueHasCommentsSinceStale) &&
                 !issue.markedStaleThisRun) {
                 issueLogger.info(`Remove the stale label since the $$type has been updated and the workflow should remove the stale label when updated`);
                 yield this._removeStaleLabel(issue, staleLabel);
@@ -755,7 +755,9 @@ class IssuesProcessor {
             if (daysBeforeClose < 0) {
                 return; // Nothing to do because we aren't closing stale issues
             }
-            if (!issueHasComments && !issueHasUpdate) {
+            const issueHasUpdateInCloseWindow = IssuesProcessor._updatedSince(issue.updated_at, daysBeforeClose);
+            issueLogger.info(`$$type has been updated in the last ${daysBeforeClose} days: ${logger_service_1.LoggerService.cyan(issueHasUpdateInCloseWindow)}`);
+            if (!issueHasCommentsSinceStale && !issueHasUpdateInCloseWindow) {
                 issueLogger.info(`Closing $$type because it was last updated on: ${logger_service_1.LoggerService.cyan(issue.updated_at)}`);
                 yield this._closeIssue(issue, closeMessage, closeLabel);
                 if (this.options.deleteBranch && issue.pull_request) {
@@ -765,7 +767,7 @@ class IssuesProcessor {
                 }
             }
             else {
-                issueLogger.info(`Stale $$type is not old enough to close yet (hasComments? ${issueHasComments}, hasUpdate? ${issueHasUpdate})`);
+                issueLogger.info(`Stale $$type is not old enough to close yet (hasComments? ${issueHasCommentsSinceStale}, hasUpdate? ${issueHasUpdateInCloseWindow})`);
             }
         });
     }

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -625,13 +625,15 @@ export class IssuesProcessor {
       `$$type marked stale on: ${LoggerService.cyan(markedStaleOn)}`
     );
 
-    const issueHasComments: boolean = await this._hasCommentsSince(
+    const issueHasCommentsSinceStale: boolean = await this._hasCommentsSince(
       issue,
       markedStaleOn,
       staleMessage
     );
     issueLogger.info(
-      `$$type has been commented on: ${LoggerService.cyan(issueHasComments)}`
+      `$$type has been commented on: ${LoggerService.cyan(
+        issueHasCommentsSinceStale
+      )}`
     );
 
     const daysBeforeClose: number = issue.isPullRequest
@@ -640,14 +642,6 @@ export class IssuesProcessor {
 
     issueLogger.info(
       `Days before $$type close: ${LoggerService.cyan(daysBeforeClose)}`
-    );
-
-    const issueHasUpdate: boolean = IssuesProcessor._updatedSince(
-      issue.updated_at,
-      daysBeforeClose
-    );
-    issueLogger.info(
-      `$$type has been updated: ${LoggerService.cyan(issueHasUpdate)}`
     );
 
     const shouldRemoveStaleWhenUpdated: boolean =
@@ -671,10 +665,19 @@ export class IssuesProcessor {
       issueLogger.info(`marked stale this run, so don't check for updates`);
     }
 
+    const issueHasUpdateSinceStale =
+      new Date(issue.updated_at) > new Date(markedStaleOn);
+
+    issueLogger.info(
+      `$$type has been updated since it was marked stale: ${LoggerService.cyan(
+        issueHasUpdateSinceStale
+      )}`
+    );
+
     // Should we un-stale this issue?
     if (
       shouldRemoveStaleWhenUpdated &&
-      (issueHasUpdate || issueHasComments) &&
+      (issueHasUpdateSinceStale || issueHasCommentsSinceStale) &&
       !issue.markedStaleThisRun
     ) {
       issueLogger.info(
@@ -696,7 +699,17 @@ export class IssuesProcessor {
       return; // Nothing to do because we aren't closing stale issues
     }
 
-    if (!issueHasComments && !issueHasUpdate) {
+    const issueHasUpdateInCloseWindow: boolean = IssuesProcessor._updatedSince(
+      issue.updated_at,
+      daysBeforeClose
+    );
+    issueLogger.info(
+      `$$type has been updated in the last ${daysBeforeClose} days: ${LoggerService.cyan(
+        issueHasUpdateInCloseWindow
+      )}`
+    );
+
+    if (!issueHasCommentsSinceStale && !issueHasUpdateInCloseWindow) {
       issueLogger.info(
         `Closing $$type because it was last updated on: ${LoggerService.cyan(
           issue.updated_at
@@ -715,7 +728,7 @@ export class IssuesProcessor {
       }
     } else {
       issueLogger.info(
-        `Stale $$type is not old enough to close yet (hasComments? ${issueHasComments}, hasUpdate? ${issueHasUpdate})`
+        `Stale $$type is not old enough to close yet (hasComments? ${issueHasCommentsSinceStale}, hasUpdate? ${issueHasUpdateInCloseWindow})`
       );
     }
   }


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes

When we introduced #717, we inadvertently introduced a bug that would occur when `days-before-close` > `days-before-stale`. 

### Example:
`days-before-stale: 0` and `days-before-close: 30`

Every issue should be `stale` in this scenario and the `stale` label would be applied as expected. The problem was is that the action would look back `30` days and ALWAYS see an update and immediately remove the stale label. 

My changes change the logic that can potentially "un-stale" an issue. Rather than check for an update in the last `days-before-close` days (e.g. 30), I check if the update occurred AFTER the stale date. This is subtle, but caused big issues for actions when `days-before-close` > `days-before-stale`

## Context
fixes #774 
<!-- Explain why you're making the change(s). -->
<!-- If you're closing an issue with this PR, [link them with a keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->
