### PR TITLE
docs(readme): add missing permission for delete-branch option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ The configuration must be on the default branch and the default values will:
 ## Recommended permissions
 
 For the execution of this action, it must be able to fetch all issues and pull requests from your repository.  
-In addition, based on the provided configuration, the action could require more permission(s) (e.g.: add label, remove label, comment, close, etc.).  
+In addition, based on the provided configuration, the action could require more permission(s) (e.g.: add label, remove label, comment, close, delete branch, etc.).  
 This can be achieved with the following [configuration in the action](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions) if the permissions are restricted:
 
 ```yaml
 permissions:
+  contents: write # only for delete-branch option
   issues: write
   pull-requests: write
 ```
@@ -396,7 +397,7 @@ Default value: unset
 If set to `true`, the stale workflow will automatically delete the GitHub branches related to the pull requests automatically closed by the stale workflow.
 
 Default value: `false`  
-Required Permission: `pull-requests: write`
+Required Permission: `pull-requests: write` and `contents: write`
 
 #### exempt-milestones
 


### PR DESCRIPTION
## Changes

- [x] add missing `contents: write` permission to `delete-branch` option in readme

## Context

Updating readme to include a permission that is required for `delete-branch` option that is missing from the readme. Configuring this workflow with that additional permission should prevent issues like https://github.com/actions/stale/issues/587 from being raised again (https://github.com/actions/stale/issues/587 wasn't actually resolved, just closed by a bot due to inactivity).

I have recently implemented this workflow in a repository configured with `delete-branch: true`. After the initial wait period, it started closing stale pull requests, but kept failing when trying to delete corresponding branches with the following error `Error when deleting the branch "BRANCH_NAME" from pull request: Resource not accessible by integration`. 

![image](https://user-images.githubusercontent.com/15880892/185157479-10b0bfff-12b0-4cba-b43c-7f9ca33447c4.png)

Searching for answers I found the issue https://github.com/actions/stale/issues/587 mentioned above, where someone had the same problem, however no solution was provided there. Looking through the code, I found that [this step](https://github.com/actions/stale/blob/main/src/classes/issues-processor.ts#L920) is executed with the [`deleteRef` action of the Octokit library](https://octokit.github.io/rest.js/v18#git-delete-ref), which in turn makes a request to the following [GitHub REST API delete reference endpoint](https://docs.github.com/en/rest/git/refs#delete-a-reference). According to [GitHub REST API docs, that endpoint requires `contents: write` permission](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-contents).

As the recommended permissions mentioned in [_Stale_ readme](https://github.com/actions/stale#recommended-permissions) are set to `issues: write` and `pull-requests: write`, [any other permissions that are absent from the list are set to `none`](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#setting-permissions-in-the-workflow), therefore blocking `delete-branch` step from successfully executing. 

After adding `contents: write` permission to the workflow configuration, when _Stale_ workflow closed the next stale pull request, it successfully deleted the corresponding branch.

![image](https://user-images.githubusercontent.com/15880892/185175826-ef0ad858-07e4-47a4-8e3d-251a7886d228.png)





