### PR TITLE
fix(options)!: Make `not_planned` the default `close-issue-reason`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Every argument is optional.
 | [close-pr-message](#close-pr-message)                               | Comment on the staled PRs while closed                                      |                       |
 | [stale-issue-label](#stale-issue-label)                             | Label to apply on staled issues                                             | `Stale`               |
 | [close-issue-label](#close-issue-label)                             | Label to apply on closed issues                                             |                       |
-| [close-issue-reason](#close-issue-reason)                           | Reason to use when closing issues                                           |                       |
+| [close-issue-reason](#close-issue-reason)                           | Reason to use when closing issues                                           | `not_planned`         |
 | [stale-pr-label](#stale-pr-label)                                   | Label to apply on staled PRs                                                | `Stale`               |
 | [close-pr-label](#close-pr-label)                                   | Label to apply on closed PRs                                                |                       |
 | [exempt-issue-labels](#exempt-issue-labels)                         | Labels on issues exempted from stale                                        |                       |
@@ -226,7 +226,7 @@ Required Permission: `issues: write`
 
 Specify the [reason](https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/) used when closing issues. Valid values are `completed` and `not_planned`.
 
-Default value: unset
+Default value: `not_planned`
 
 #### stale-pr-label
 

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -1,5 +1,7 @@
 import {IIssuesProcessorOptions} from '../../src/interfaces/issues-processor-options';
 
+// Default options for use in tests.
+// Mirrors the defaults defined in action.yml
 export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   repoToken: 'none',
   staleIssueMessage: 'This issue is stale',

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -53,6 +53,6 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   ignoreIssueUpdates: undefined,
   ignorePrUpdates: undefined,
   exemptDraftPr: false,
-  closeIssueReason: '',
+  closeIssueReason: 'not_planned',
   includeOnlyAssigned: false
 });

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
     required: false
   close-issue-reason:
     description: 'The reason to use when closing an issue.'
-    default: ''
+    default: 'not_planned'
     required: false
   stale-pr-label:
     description: 'The label to apply when a pull request is stale.'


### PR DESCRIPTION
## Changes

- [x] ⚠️ **BREAKING CHANGE** `close-issue-reason` defaults to `not_planned` (previously: ``
which defaulted to `completed`) This closes the issue as 'not planned' on GitHub rather than 'completed'
- [x] documentation: minor improvement to 'DefaultProcessorOptions'
   - I'm happy to drop this if it's an issue - unsure on PR requirements for this repo

## Context

GitHub introduced an additional close reason 'Close as not planned':
https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/

'stale' is a use case for this close reason and makes sense as a default for this action

Fixes https://github.com/actions/stale/issues/789

Feature added: https://github.com/actions/stale/commit/06d2a3904b77e3b34b74319855eebe4627488d19
Updated: https://github.com/actions/stale/commit/aaab997ccea19e4bbf31972dde2a627199681ea4