### PR TITLE
Add action typings

### DIFF
--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -1,0 +1,13 @@
+name: Validate action typings
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate-typings:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: krzema12/github-actions-typing@v0

--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -3,7 +3,7 @@ name: Validate action typings
 on:
   push:
     branches:
-     - main
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -12,4 +12,5 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v3
-      - uses: krzema12/github-actions-typing@v0
+      - name: Validate typings
+        uses: krzema12/github-actions-typing@v0

--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -2,6 +2,8 @@ name: Validate action typings
 
 on:
   push:
+    branches:
+     - main
   pull_request:
   workflow_dispatch:
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,173 @@
+# See https://github.com/krzema12/github-actions-typing
+
+inputs:
+  repo-token:
+    type: string
+  stale-issue-message:
+    type: string
+  stale-pr-message:
+    type: string
+  close-issue-message:
+    type: string
+  close-pr-message:
+    type: string
+  days-before-stale:
+    type: integer
+  days-before-issue-stale:
+    type: string
+  days-before-pr-stale:
+    type: integer
+    named-values:
+      never: -1
+  days-before-close:
+    type: integer
+  days-before-issue-close:
+    type: integer
+    named-values:
+      never: -1
+  days-before-pr-close:
+    type: integer
+    named-values:
+      never: -1
+  stale-issue-label:
+    type: string
+  close-issue-label:
+    type: string
+  exempt-issue-labels:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  close-issue-reason:
+    type: string
+  stale-pr-label:
+    type: string
+  close-pr-label:
+    type: string
+  exempt-pr-labels:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  exempt-milestones:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  exempt-issue-milestones:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  exempt-pr-milestones:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  exempt-all-milestones:
+    type: boolean
+  exempt-all-issue-milestones:
+    type: boolean
+  exempt-all-pr-milestones:
+    type: boolean
+  only-labels:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  any-of-labels:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  any-of-issue-labels:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  any-of-pr-labels:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  only-issue-labels:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  only-pr-labels:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  operations-per-run:
+    type: integer
+  remove-stale-when-updated:
+    type: boolean
+  remove-issue-stale-when-updated:
+    type: boolean
+  remove-pr-stale-when-updated:
+    type: boolean
+  debug-only:
+    type: boolean
+  ascending:
+    type: boolean
+  delete-branch:
+    type: boolean
+  start-date:
+    type: string
+  exempt-assignees:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  exempt-issue-assignees:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  exempt-pr-assignees:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  exempt-all-assignees:
+    type: boolean
+  exempt-all-issue-assignees:
+    type: string
+  exempt-all-pr-assignees:
+    type: boolean
+  exempt-draft-pr:
+    type: boolean
+  enable-statistics:
+    type: boolean
+  labels-to-add-when-unstale:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  labels-to-remove-when-unstale:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  ignore-updates:
+    type: boolean
+  ignore-issue-updates:
+    type: boolean
+  ignore-pr-updates:
+    type: boolean
+  include-only-assigned:
+    type: boolean
+
+outputs:
+  closed-issues-prs:
+    type: list
+    separator: ','
+    list-item:
+      type: string
+  staled-issues-prs:
+    type: list
+    separator: ','
+    list-item:
+      type: string

--- a/dist/index.js
+++ b/dist/index.js
@@ -2487,7 +2487,6 @@ const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
 const os = __importStar(__nccwpck_require__(2087));
 const path = __importStar(__nccwpck_require__(5622));
-const uuid_1 = __nccwpck_require__(5840);
 const oidc_utils_1 = __nccwpck_require__(8041);
 /**
  * The code to exit an action
@@ -2517,20 +2516,9 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
-        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
-        if (name.includes(delimiter)) {
-            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
-        }
-        if (convertedVal.includes(delimiter)) {
-            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
-        }
-        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
+        return file_command_1.issueFileCommand('ENV', file_command_1.prepareKeyValueMessage(name, val));
     }
-    else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
-    }
+    command_1.issueCommand('set-env', { name }, convertedVal);
 }
 exports.exportVariable = exportVariable;
 /**
@@ -2548,7 +2536,7 @@ exports.setSecret = setSecret;
 function addPath(inputPath) {
     const filePath = process.env['GITHUB_PATH'] || '';
     if (filePath) {
-        file_command_1.issueCommand('PATH', inputPath);
+        file_command_1.issueFileCommand('PATH', inputPath);
     }
     else {
         command_1.issueCommand('add-path', {}, inputPath);
@@ -2588,7 +2576,10 @@ function getMultilineInput(name, options) {
     const inputs = getInput(name, options)
         .split('\n')
         .filter(x => x !== '');
-    return inputs;
+    if (options && options.trimWhitespace === false) {
+        return inputs;
+    }
+    return inputs.map(input => input.trim());
 }
 exports.getMultilineInput = getMultilineInput;
 /**
@@ -2621,8 +2612,12 @@ exports.getBooleanInput = getBooleanInput;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
+    const filePath = process.env['GITHUB_OUTPUT'] || '';
+    if (filePath) {
+        return file_command_1.issueFileCommand('OUTPUT', file_command_1.prepareKeyValueMessage(name, value));
+    }
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, value);
+    command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
 }
 exports.setOutput = setOutput;
 /**
@@ -2751,7 +2746,11 @@ exports.group = group;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function saveState(name, value) {
-    command_1.issueCommand('save-state', { name }, value);
+    const filePath = process.env['GITHUB_STATE'] || '';
+    if (filePath) {
+        return file_command_1.issueFileCommand('STATE', file_command_1.prepareKeyValueMessage(name, value));
+    }
+    command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
 }
 exports.saveState = saveState;
 /**
@@ -2817,13 +2816,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.issueCommand = void 0;
+exports.prepareKeyValueMessage = exports.issueFileCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(5747));
 const os = __importStar(__nccwpck_require__(2087));
+const uuid_1 = __nccwpck_require__(5840);
 const utils_1 = __nccwpck_require__(5278);
-function issueCommand(command, message) {
+function issueFileCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`);
@@ -2835,7 +2835,22 @@ function issueCommand(command, message) {
         encoding: 'utf8'
     });
 }
-exports.issueCommand = issueCommand;
+exports.issueFileCommand = issueFileCommand;
+function prepareKeyValueMessage(key, value) {
+    const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+    const convertedValue = utils_1.toCommandValue(value);
+    // These should realistically never happen, but just in case someone finds a
+    // way to exploit uuid generation let's not allow keys or values that contain
+    // the delimiter.
+    if (key.includes(delimiter)) {
+        throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+    }
+    if (convertedValue.includes(delimiter)) {
+        throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+    }
+    return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
+}
+exports.prepareKeyValueMessage = prepareKeyValueMessage;
 //# sourceMappingURL=file-command.js.map
 
 /***/ }),


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes

- add action typings according to https://github.com/krzema12/github-actions-typing/

## Context

GitHub's actions generally lack a standardized way to expose information about types of their inputs and outputs. It's hard both for the users and for automation that may want to rely on it. Thanks to https://github.com/krzema12/github-actions-typing/, types are provided in automation-friendly way. One of such pieces of automation is a Kotlin DSL for authoring GitHub workflows: https://github.com/krzema12/github-actions-kotlin-dsl

Ideally GitHub should provide a way of defining these in e. g. action.yml, but it's not supported yet. Adding typings using https://github.com/krzema12/github-actions-typing/ is an iterative step towards having the typings. Possibly one day first-class support from GitHub will be added, and until then the typings added in this PR can greatly help.

For more info, please read the project's README.
