### PR TITLE
Allow daysBeforeStale options to be float

### DIFF
--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -1998,6 +1998,84 @@ test('processing an issue opened since 2 days and with the option "daysBeforeIss
   expect(processor.closedIssues).toHaveLength(0);
 });
 
+test('processing an issue opened since 1 hour and with the option "daysBeforeIssueStale" at 0.1666666667 (4 hours) will not make it stale', async () => {
+  expect.assertions(2);
+  const opts: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: 10,
+    daysBeforeIssueStale: 0.1666666667
+  };
+  const issueDate = new Date();
+  issueDate.setHours(issueDate.getHours() - 1);
+  const TestIssueList: Issue[] = [
+    generateIssue(opts, 1, 'An issue with no label', issueDate.toISOString())
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [],
+    async () => new Date().toISOString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues).toHaveLength(0);
+  expect(processor.closedIssues).toHaveLength(0);
+});
+
+test('processing an issue opened since 4 hours and with the option "daysBeforeIssueStale" at 0.1666666667 (4 hours) will make it stale', async () => {
+  expect.assertions(2);
+  const opts: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: 10,
+    daysBeforeIssueStale: 0.1666666667
+  };
+  const issueDate = new Date();
+  issueDate.setHours(issueDate.getHours() - 4);
+  const TestIssueList: Issue[] = [
+    generateIssue(opts, 1, 'An issue with no label', issueDate.toISOString())
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [],
+    async () => new Date().toISOString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues).toHaveLength(1);
+  expect(processor.closedIssues).toHaveLength(0);
+});
+
+test('processing an issue opened since 5 hours and with the option "daysBeforeIssueStale" at 0.1666666667 (4 hours) will make it stale', async () => {
+  expect.assertions(2);
+  const opts: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: 10,
+    daysBeforeIssueStale: 0.1666666667
+  };
+  const issueDate = new Date();
+  issueDate.setHours(issueDate.getHours() - 5);
+  const TestIssueList: Issue[] = [
+    generateIssue(opts, 1, 'An issue with no label', issueDate.toISOString())
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [],
+    async () => new Date().toISOString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues).toHaveLength(1);
+  expect(processor.closedIssues).toHaveLength(0);
+});
+
 test('processing a pull request opened since 2 days and with the option "daysBeforePrStale" at 3 will not make it stale', async () => {
   expect.assertions(2);
   const opts: IIssuesProcessorOptions = {
@@ -2088,6 +2166,105 @@ test('processing a pull request opened since 2 days and with the option "daysBef
     async p => (p === 1 ? TestIssueList : []),
     async () => [],
     async () => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues).toHaveLength(1);
+  expect(processor.closedIssues).toHaveLength(0);
+});
+
+test('processing a pull request opened since 1 hour and with the option "daysBeforePrStale" at 0.1666666667 (4 hours) will not make it stale', async () => {
+  expect.assertions(2);
+  const opts: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: 10,
+    daysBeforePrStale: 0.1666666667
+  };
+  const issueDate = new Date();
+  issueDate.setHours(issueDate.getHours() - 1);
+  const TestIssueList: Issue[] = [
+    generateIssue(
+      opts,
+      1,
+      'A pull request with no label',
+      issueDate.toISOString(),
+      issueDate.toISOString(),
+      true
+    )
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [],
+    async () => new Date().toISOString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues).toHaveLength(0);
+  expect(processor.closedIssues).toHaveLength(0);
+});
+
+test('processing a pull request opened since 4 hours and with the option "daysBeforePrStale" at 0.1666666667 (4 hours) will make it stale', async () => {
+  expect.assertions(2);
+  const opts: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: 10,
+    daysBeforePrStale: 0.1666666667
+  };
+  const issueDate = new Date();
+  issueDate.setHours(issueDate.getHours() - 4);
+  const TestIssueList: Issue[] = [
+    generateIssue(
+      opts,
+      1,
+      'A pull request with no label',
+      issueDate.toISOString(),
+      issueDate.toISOString(),
+      true
+    )
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [],
+    async () => new Date().toISOString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.staleIssues).toHaveLength(1);
+  expect(processor.closedIssues).toHaveLength(0);
+});
+
+test('processing a pull request opened since 5 hours and with the option "daysBeforePrStale" at 0.1666666667 (4 hours) will make it stale', async () => {
+  expect.assertions(2);
+  const opts: IIssuesProcessorOptions = {
+    ...DefaultProcessorOptions,
+    daysBeforeStale: 10,
+    daysBeforePrStale: 0.1666666667
+  };
+  const issueDate = new Date();
+  issueDate.setHours(issueDate.getHours() - 5);
+  const TestIssueList: Issue[] = [
+    generateIssue(
+      opts,
+      1,
+      'A pull request with no label',
+      issueDate.toISOString(),
+      issueDate.toISOString(),
+      true
+    )
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [],
+    async () => new Date().toISOString()
   );
 
   // process our fake issue list

--- a/dist/index.js
+++ b/dist/index.js
@@ -2183,9 +2183,9 @@ function _getAndValidateArgs() {
         stalePrMessage: core.getInput('stale-pr-message'),
         closeIssueMessage: core.getInput('close-issue-message'),
         closePrMessage: core.getInput('close-pr-message'),
-        daysBeforeStale: parseInt(core.getInput('days-before-stale', { required: true })),
-        daysBeforeIssueStale: parseInt(core.getInput('days-before-issue-stale')),
-        daysBeforePrStale: parseInt(core.getInput('days-before-pr-stale')),
+        daysBeforeStale: parseFloat(core.getInput('days-before-stale', { required: true })),
+        daysBeforeIssueStale: parseFloat(core.getInput('days-before-issue-stale')),
+        daysBeforePrStale: parseFloat(core.getInput('days-before-pr-stale')),
         daysBeforeClose: parseInt(core.getInput('days-before-close', { required: true })),
         daysBeforeIssueClose: parseInt(core.getInput('days-before-issue-close')),
         daysBeforePrClose: parseInt(core.getInput('days-before-pr-close')),
@@ -2233,11 +2233,14 @@ function _getAndValidateArgs() {
         closeIssueReason: core.getInput('close-issue-reason'),
         includeOnlyAssigned: core.getInput('include-only-assigned') === 'true'
     };
-    for (const numberInput of [
-        'days-before-stale',
-        'days-before-close',
-        'operations-per-run'
-    ]) {
+    for (const numberInput of ['days-before-stale']) {
+        if (isNaN(parseFloat(core.getInput(numberInput)))) {
+            const errorMessage = `Option "${numberInput}" did not parse to a valid float`;
+            core.setFailed(errorMessage);
+            throw new Error(errorMessage);
+        }
+    }
+    for (const numberInput of ['days-before-close', 'operations-per-run']) {
         if (isNaN(parseInt(core.getInput(numberInput)))) {
             const errorMessage = `Option "${numberInput}" did not parse to a valid integer`;
             core.setFailed(errorMessage);

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,11 +28,11 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     stalePrMessage: core.getInput('stale-pr-message'),
     closeIssueMessage: core.getInput('close-issue-message'),
     closePrMessage: core.getInput('close-pr-message'),
-    daysBeforeStale: parseInt(
+    daysBeforeStale: parseFloat(
       core.getInput('days-before-stale', {required: true})
     ),
-    daysBeforeIssueStale: parseInt(core.getInput('days-before-issue-stale')),
-    daysBeforePrStale: parseInt(core.getInput('days-before-pr-stale')),
+    daysBeforeIssueStale: parseFloat(core.getInput('days-before-issue-stale')),
+    daysBeforePrStale: parseFloat(core.getInput('days-before-pr-stale')),
     daysBeforeClose: parseInt(
       core.getInput('days-before-close', {required: true})
     ),
@@ -92,11 +92,15 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     includeOnlyAssigned: core.getInput('include-only-assigned') === 'true'
   };
 
-  for (const numberInput of [
-    'days-before-stale',
-    'days-before-close',
-    'operations-per-run'
-  ]) {
+  for (const numberInput of ['days-before-stale']) {
+    if (isNaN(parseFloat(core.getInput(numberInput)))) {
+      const errorMessage = `Option "${numberInput}" did not parse to a valid float`;
+      core.setFailed(errorMessage);
+      throw new Error(errorMessage);
+    }
+  }
+
+  for (const numberInput of ['days-before-close', 'operations-per-run']) {
     if (isNaN(parseInt(core.getInput(numberInput)))) {
       const errorMessage = `Option "${numberInput}" did not parse to a valid integer`;
       core.setFailed(errorMessage);


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes

- [x] Modifies the initialization of the input options `daysBeforeStale`, `daysBeforeIssueStale` and `daysBeforePrStale` to perform a `parseFloat` instead of `parseInt`.
- [x] Adds new test cases to cover the cases where those params are used with hours instead of full days. 

## Context

Resolves #833 

<!-- Explain why you're making the change(s). -->
<!-- If you're closing an issue with this PR, [link them with a keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->
