### PR TITLE
fix print outputs step in existing workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,4 +16,4 @@ jobs:
           days-before-close: 5
           exempt-issue-labels: 'blocked,must,should,keep'
       - name: Print outputs
-        run: echo ${{ join(steps.stale.outputs.*, ',') }}
+        run: echo ${{ format('{0},{1}', toJSON(steps.stale.outputs.staled-issues-prs), toJSON(steps.stale.outputs.closed-issues-prs)) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
           stale-pr-message: 'This PR is stale'
           debug-only: true
       - name: Print outputs
-        run: echo ${{ join(steps.stale.outputs.*, ',') }}
+        run: echo ${{ format('{0},{1}', toJSON(steps.stale.outputs.staled-issues-prs), toJSON(steps.stale.outputs.closed-issues-prs)) }}


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes

- [x] Use [format](https://docs.github.com/en/actions/learn-github-actions/expressions#format) and [toJSON](https://docs.github.com/en/actions/learn-github-actions/expressions#tojson) expressions to fix the `Print outputs` which is causing the current workflows failing.

## Context

<!-- Explain why you're making the change(s). -->
<!-- If you're closing an issue with this PR, [link them with a keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). -->
The current workflows are failing in the repo, they are stuck in the `Print outputs` step. After debugging them using [act](https://github.com/nektos/act), I realized the outputs were printed wrong, repeating all the properties from each array element over and over again, such as:

```
[operations:{_operationsConsumed:4},operations:{_operationsConsumed:4}] 
[operations:{_operationsConsumed:4},_options:repoToken:***] 
[operations:{_operationsConsumed:4},_options:staleIssueMessage:This issue is stale] 
[operations:{_operationsConsumed:4},_options:stalePrMessage:This PR is stale] 
[operations:{_operationsConsumed:4},_options:closeIssueMessage:] 
[operations:{_operationsConsumed:4},_options:closePrMessage:] 
...
```
The error is more notorious now and causes the workflows failing due to we have more staled/closed issues and pull requests in the repo. 

Using the [toJSON](https://docs.github.com/en/actions/learn-github-actions/expressions#tojson) expression to get a pretty-print JSON representation for each output fixes the problem.