### PR TITLE
corrected readme messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ jobs:
       - uses: actions/stale@v6
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
           days-before-stale: 30
           days-before-close: 5


### PR DESCRIPTION
<!-- List the change(s) you're making with this PR. -->

## Changes

Updated the string messages in the "Configure different stale timeouts but never close a PR" example to match what is defined in the `days-before-X` values.

## Context

The stale PR message was incorrect, in the example. It appears that the string value was copied from the next example, "Configure different stale timeouts." In the example that was corrected, `days-before-stale` is set to `30`, and no PR override is used. But there is a `days-before-pr-close` value of `-1`, which, if I understand the docs correctly, means that PRs will not be closed. Just messaged. 

So I've changed the PR messaging to reflect the `30` days, and removed mention of closing the PR.
