### PR TITLE
Use cache in check-dist.yml

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Use cache in `check-dist.yml`
See [actions/cache#1004](https://github.com/actions/cache/pull/1004)

**AS-IS**

```yaml
- name: Set Node.js 16.x
  uses: actions/setup-node@v3
  with:
    node-version: 16.x
```

**TO-BE**

```yaml
- name: Set Node.js 16.x
  uses: actions/setup-node@v3
  with:
    node-version: 16.x
    cache: npm
```

> It’s literally a one line change to pass the `cache: npm` input parameter.