### PR TITLE
Skip deleting the branch in the upstream of a forked repo

### DIFF
--- a/__tests__/exempt-draft-pr.spec.ts
+++ b/__tests__/exempt-draft-pr.spec.ts
@@ -130,7 +130,8 @@ class IssuesProcessorBuilder {
           number: 0,
           draft: true,
           head: {
-            ref: 'ref'
+            ref: 'ref',
+            repo: null
           }
         });
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -917,20 +917,27 @@ class IssuesProcessor {
                 return;
             }
             const branch = pullRequest.head.ref;
-            issueLogger.info(`Deleting the branch "${logger_service_1.LoggerService.cyan(branch)}" from closed $$type`);
-            try {
-                this._consumeIssueOperation(issue);
-                (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementDeletedBranchesCount();
-                if (!this.options.debugOnly) {
-                    yield this.client.rest.git.deleteRef({
-                        owner: github_1.context.repo.owner,
-                        repo: github_1.context.repo.repo,
-                        ref: `heads/${branch}`
-                    });
+            if (pullRequest.head.repo === null ||
+                pullRequest.head.repo.full_name ===
+                    `${github_1.context.repo.owner}/${github_1.context.repo.repo}`) {
+                issueLogger.info(`Deleting the branch "${logger_service_1.LoggerService.cyan(branch)}" from closed $$type`);
+                try {
+                    this._consumeIssueOperation(issue);
+                    (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementDeletedBranchesCount();
+                    if (!this.options.debugOnly) {
+                        yield this.client.rest.git.deleteRef({
+                            owner: github_1.context.repo.owner,
+                            repo: github_1.context.repo.repo,
+                            ref: `heads/${branch}`
+                        });
+                    }
+                }
+                catch (error) {
+                    issueLogger.error(`Error when deleting the branch "${logger_service_1.LoggerService.cyan(branch)}" from $$type: ${error.message}`);
                 }
             }
-            catch (error) {
-                issueLogger.error(`Error when deleting the branch "${logger_service_1.LoggerService.cyan(branch)}" from $$type: ${error.message}`);
+            else {
+                issueLogger.warning(`Deleting the branch "${logger_service_1.LoggerService.cyan(branch)}" has skipped because it belongs to other repo ${pullRequest.head.repo.full_name}`);
             }
         });
     }

--- a/src/interfaces/pull-request.ts
+++ b/src/interfaces/pull-request.ts
@@ -2,6 +2,9 @@ export interface IPullRequest {
   number: number;
   head: {
     ref: string;
+    repo: {
+      full_name: string;
+    } | null;
   };
   draft?: boolean;
 }


### PR DESCRIPTION
**Description:**
Handle an attempt of the deleting a branch in a forked repo

When the action runs against the repo that has PRs from the forked repo it attempted to delete the branch from the fork repo and failed.

The PR fix this.

**Related issue:**
[link to the related issue.](https://github.com/actions/stale/issues/881)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
