### PR TITLE
Update docs for close-pr-message permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Required Permission: `issues: write`
 The message that will be added as a comment to the pull requests when the stale workflow closes it automatically after being stale for too long.
 
 Default value: unset  
-Required Permission: `pull-requests: write`
+Required Permission: `pull-requests: write` and `issues: write`
 
 #### stale-issue-label
 


### PR DESCRIPTION
**Description:**
Based on my experience in https://github.com/actions/stale/issues/840 and [Github docs](https://github.com/actions/stale/issues/840) example, it seems stable action needs to `issues: write` even if the stale job is only working with PRs and not issues. 

**Related issue:**
Resolves https://github.com/actions/stale/issues/840

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
