### PR TITLE
fix: remove references to npm pack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ $ npm install
 Build the typescript and package it for distribution.
 
 ```bash
-$ npm run build && npm run pack
+$ npm run build
 ```
 
 Run the tests :heavy_check_mark:
@@ -49,7 +49,7 @@ $ npm run all
 IMPORTANT:
 Be sure to commit the result of:
 ```bash
-$ npm run pack
+$ npm run build
 ```
 Otherwise PR checks will fail. 
 


### PR DESCRIPTION
**Description:**
The pack target no longer exists and related
packing is built into the npm build script target

**Related issue:**
N/A
**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
