### PR TITLE
Update Semver to 7.5.4 and add licensing

### DIFF
--- a/.licenses/npm/semver-7.5.4.dep.yml
+++ b/.licenses/npm/semver-7.5.4.dep.yml
@@ -1,0 +1,26 @@
+---
+name: semver
+version: 7.5.4
+type: npm
+summary: The semantic version parser used by npm.
+homepage:
+license: isc
+licenses:
+- sources: LICENSE
+  text: |
+    The ISC License
+
+    Copyright (c) Isaac Z. Schlueter and Contributors
+
+    Permission to use, copy, modify, and/or distribute this software for any
+    purpose with or without fee is hereby granted, provided that the above
+    copyright notice and this permission notice appear in all copies.
+
+    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+    ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+    IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+notices: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@octokit/core": "^4.2.0",
         "@octokit/plugin-retry": "^4.1.1",
         "lodash.deburr": "^4.1.0",
-        "semver": "^7.3.5"
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",
@@ -6499,9 +6499,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12393,9 +12393,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/jest": "^29.5.0",
         "@types/lodash.deburr": "^4.1.6",
         "@types/node": "^18.15.11",
-        "@types/semver": "^7.3.5",
+        "@types/semver": "^7.5.0",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.56.0",
         "@vercel/ncc": "^0.36.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@octokit/core": "^4.2.0",
     "@octokit/plugin-retry": "^4.1.1",
     "lodash.deburr": "^4.1.0",
-    "semver": "^7.3.5"
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/jest": "^29.5.0",
     "@types/lodash.deburr": "^4.1.6",
     "@types/node": "^18.15.11",
-    "@types/semver": "^7.3.5",
+    "@types/semver": "^7.5.0",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.56.0",
     "@vercel/ncc": "^0.36.1",


### PR DESCRIPTION
**Description:**
In the scope of this PR is a simple Semver version update (from `7.5.3` to `7.5.4`). I mostly created this PR because I noticed after looking into https://github.com/actions/stale/pull/1011 that `package.json` still had an old version (`7.3.5`) while the ones in `package-lock` were bumped to `7.5.1`. Potentially, due to the fact that the PR above is old, it created some merge conflicts, so doing it this way was probably more efficient.

Unit tests were ran prior to committing and no errors were thrown.

**Related issue:**
[Add link to the related issue.](https://github.com/actions/stale/pull/1011)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
