### PR TITLE
Do not restore state if the cache does not exist

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1615,7 +1615,7 @@ const getOctokitClient = () => {
     const token = core.getInput('repo-token');
     return (0, github_1.getOctokit)(token, undefined, plugin_retry_1.retry);
 };
-const checkCacheExist = (cacheKey) => __awaiter(void 0, void 0, void 0, function* () {
+const checkIfCacheExists = (cacheKey) => __awaiter(void 0, void 0, void 0, function* () {
     const client = getOctokitClient();
     try {
         const issueResult = yield client.request(`/repos/${github_1.context.repo.owner}/${github_1.context.repo.repo}/actions/caches`);
@@ -1623,7 +1623,7 @@ const checkCacheExist = (cacheKey) => __awaiter(void 0, void 0, void 0, function
         return Boolean(caches.find(cache => cache['key'] === cacheKey));
     }
     catch (error) {
-        core.debug(`$Error checking if cache exist: ${error.message}`);
+        core.debug(`Error checking if cache exist: ${error.message}`);
     }
     return false;
 });
@@ -1672,8 +1672,8 @@ class StateCacheStorage {
             const filePath = path_1.default.join(tmpDir, STATE_FILE);
             unlinkSafely(filePath);
             try {
-                const cacheExist = yield checkCacheExist(CACHE_KEY);
-                if (!cacheExist) {
+                const cacheExists = yield checkIfCacheExists(CACHE_KEY);
+                if (!cacheExists) {
                     core.info('The saved state was not found, the process starts from the first issue.');
                     return '';
                 }

--- a/src/classes/state/state-cache-storage.ts
+++ b/src/classes/state/state-cache-storage.ts
@@ -30,7 +30,7 @@ const getOctokitClient = () => {
   return getOctokit(token, undefined, octokitRetry);
 };
 
-const checkCacheExist = async (cacheKey: string): Promise<boolean> => {
+const checkIfCacheExists = async (cacheKey: string): Promise<boolean> => {
   const client = getOctokitClient();
   try {
     const issueResult = await client.request(
@@ -40,7 +40,7 @@ const checkCacheExist = async (cacheKey: string): Promise<boolean> => {
       issueResult.data['actions_caches'] || [];
     return Boolean(caches.find(cache => cache['key'] === cacheKey));
   } catch (error) {
-    core.debug(`$Error checking if cache exist: ${error.message}`);
+    core.debug(`Error checking if cache exist: ${error.message}`);
   }
   return false;
 };
@@ -92,8 +92,8 @@ export class StateCacheStorage implements IStateStorage {
     const filePath = path.join(tmpDir, STATE_FILE);
     unlinkSafely(filePath);
     try {
-      const cacheExist = await checkCacheExist(CACHE_KEY);
-      if (!cacheExist) {
+      const cacheExists = await checkIfCacheExists(CACHE_KEY);
+      if (!cacheExists) {
         core.info(
           'The saved state was not found, the process starts from the first issue.'
         );

--- a/src/classes/state/state.ts
+++ b/src/classes/state/state.ts
@@ -64,8 +64,9 @@ export class State implements IState {
     this.reset();
     const serialized = await this.stateStorage.restore();
     this.deserialize(serialized);
-    core.info(
-      `state: restored with info about ${this.processedIssuesIDs.size} issue(s)`
-    );
+    if (this.processedIssuesIDs.size > 0)
+      core.info(
+        `state: restored with info about ${this.processedIssuesIDs.size} issue(s)`
+      );
   }
 }


### PR DESCRIPTION
**Description:**
Use https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#list-github-actions-caches-for-a-repository
to check if the cache exists and skip the restore if it does not.

Logging is also changed, since state recovery can only fail because of the error. 

e2e run: https://github.com/akv-demo/test-stale/actions/runs/5615517213/job/15215993242

**Related issue:**
[link to the original issue.](https://github.com/github/c2c-actions-akvelon/issues/32)
[link to the related issue.](https://github.com/actions/runner-images-internal/issues/5239)


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
