### PR TITLE
Fix logging

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -998,7 +998,7 @@ class IssuesProcessor {
                 issueLogger.info(`${isSubStep ? logger_service_1.LoggerService.white('└── ') : ''}The label "${logger_service_1.LoggerService.cyan(label)}" was removed`);
             }
             catch (error) {
-                issueLogger.error(`${isSubStep ? logger_service_1.LoggerService.white('└── ') : ''}Error when removing the label: "${logger_service_1.LoggerService.cyan(error.message)}"`);
+                issueLogger.error(`${isSubStep ? logger_service_1.LoggerService.white('└── ') : ''}Error when removing the label: ${logger_service_1.LoggerService.cyan(error.message)}`);
             }
         });
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -425,16 +425,16 @@ class IssuesProcessor {
     processIssues(page = 1) {
         var _a, _b;
         return __awaiter(this, void 0, void 0, function* () {
-            // get the next batch of issues
+            // get the next batch of items
             const issues = yield this.getIssues(page);
             if (issues.length <= 0) {
-                this._logger.info(logger_service_1.LoggerService.green(`No more issues found to process. Exiting...`));
+                this._logger.info(logger_service_1.LoggerService.green(`No more items found to process. Exiting...`));
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.setOperationsCount(this.operations.getConsumedOperationsCount()).logStats();
                 this.state.reset();
                 return this.operations.getRemainingOperationsCount();
             }
             else {
-                this._logger.info(`${logger_service_1.LoggerService.yellow('Processing the batch of issues ')} ${logger_service_1.LoggerService.cyan(`#${page}`)} ${logger_service_1.LoggerService.yellow(' containing ')} ${logger_service_1.LoggerService.cyan(issues.length)} ${logger_service_1.LoggerService.yellow(` issue${issues.length > 1 ? 's' : ''}...`)}`);
+                this._logger.info(`${logger_service_1.LoggerService.yellow('Processing the batch of items ')} ${logger_service_1.LoggerService.cyan(`#${page}`)} ${logger_service_1.LoggerService.yellow(' containing ')} ${logger_service_1.LoggerService.cyan(issues.length)} ${logger_service_1.LoggerService.yellow(` item${issues.length > 1 ? 's' : ''}...`)}`);
             }
             const labelsToRemoveWhenStale = (0, words_to_list_1.wordsToList)(this.options.labelsToRemoveWhenStale);
             const labelsToAddWhenUnstale = (0, words_to_list_1.wordsToList)(this.options.labelsToAddWhenUnstale);
@@ -456,7 +456,7 @@ class IssuesProcessor {
             }
             if (!this.operations.hasRemainingOperations()) {
                 this._logger.warning(logger_service_1.LoggerService.yellowBright(`No more operations left! Exiting...`));
-                this._logger.warning(`${logger_service_1.LoggerService.yellowBright('If you think that not enough issues were processed you could try to increase the quantity related to the ')} ${this._logger.createOptionLink(option_1.Option.OperationsPerRun)} ${logger_service_1.LoggerService.yellowBright(' option which is currently set to ')} ${logger_service_1.LoggerService.cyan(this.options.operationsPerRun)}`);
+                this._logger.warning(`${logger_service_1.LoggerService.yellowBright('If you think that not enough items were processed you could try to increase the quantity related to the ')} ${this._logger.createOptionLink(option_1.Option.OperationsPerRun)} ${logger_service_1.LoggerService.yellowBright(' option which is currently set to ')} ${logger_service_1.LoggerService.cyan(this.options.operationsPerRun)}`);
                 (_b = this.statistics) === null || _b === void 0 ? void 0 : _b.setOperationsCount(this.operations.getConsumedOperationsCount()).logStats();
                 return 0;
             }
@@ -667,7 +667,7 @@ class IssuesProcessor {
                 return comments.data;
             }
             catch (error) {
-                this._logger.error(`List issue comments error: ${error.message}`);
+                this._logger.error(`List $$type comments error: ${error.message}`);
                 return Promise.resolve([]);
             }
         });
@@ -690,7 +690,7 @@ class IssuesProcessor {
                 return issueResult.data.map((issue) => new issue_1.Issue(this.options, issue));
             }
             catch (error) {
-                throw Error(`Getting issues was blocked by the error: ${error.message}`);
+                throw Error(`Getting items was blocked by the error: ${error.message}`);
             }
         });
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -603,7 +603,7 @@ class IssuesProcessor {
             }
             // Determine if this issue needs to be marked stale first
             if (!issue.isStale) {
-                issueLogger.info(`This $$type is not stale`);
+                issueLogger.info(`This $$type is not marked stale`);
                 const shouldIgnoreUpdates = new ignore_updates_1.IgnoreUpdates(this.options, issue).shouldIgnoreUpdates();
                 // Should this issue be marked as stale?
                 let shouldBeStale;

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -104,12 +104,12 @@ export class IssuesProcessor {
   }
 
   async processIssues(page: Readonly<number> = 1): Promise<number> {
-    // get the next batch of issues
+    // get the next batch of items
     const issues: Issue[] = await this.getIssues(page);
 
     if (issues.length <= 0) {
       this._logger.info(
-        LoggerService.green(`No more issues found to process. Exiting...`)
+        LoggerService.green(`No more items found to process. Exiting...`)
       );
       this.statistics
         ?.setOperationsCount(this.operations.getConsumedOperationsCount())
@@ -121,11 +121,11 @@ export class IssuesProcessor {
     } else {
       this._logger.info(
         `${LoggerService.yellow(
-          'Processing the batch of issues '
+          'Processing the batch of items '
         )} ${LoggerService.cyan(`#${page}`)} ${LoggerService.yellow(
           ' containing '
         )} ${LoggerService.cyan(issues.length)} ${LoggerService.yellow(
-          ` issue${issues.length > 1 ? 's' : ''}...`
+          ` item${issues.length > 1 ? 's' : ''}...`
         )}`
       );
     }
@@ -171,7 +171,7 @@ export class IssuesProcessor {
       );
       this._logger.warning(
         `${LoggerService.yellowBright(
-          'If you think that not enough issues were processed you could try to increase the quantity related to the '
+          'If you think that not enough items were processed you could try to increase the quantity related to the '
         )} ${this._logger.createOptionLink(
           Option.OperationsPerRun
         )} ${LoggerService.yellowBright(
@@ -555,7 +555,7 @@ export class IssuesProcessor {
       });
       return comments.data;
     } catch (error) {
-      this._logger.error(`List issue comments error: ${error.message}`);
+      this._logger.error(`List $$type comments error: ${error.message}`);
       return Promise.resolve([]);
     }
   }
@@ -579,7 +579,7 @@ export class IssuesProcessor {
           new Issue(this.options, issue as Readonly<OctokitIssue>)
       );
     } catch (error) {
-      throw Error(`Getting issues was blocked by the error: ${error.message}`);
+      throw Error(`Getting items was blocked by the error: ${error.message}`);
     }
   }
 

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -1039,7 +1039,7 @@ export class IssuesProcessor {
       issueLogger.error(
         `${
           isSubStep ? LoggerService.white('└── ') : ''
-        }Error when removing the label: "${LoggerService.cyan(error.message)}"`
+        }Error when removing the label: ${LoggerService.cyan(error.message)}`
       );
     }
   }

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -446,7 +446,7 @@ export class IssuesProcessor {
 
     // Determine if this issue needs to be marked stale first
     if (!issue.isStale) {
-      issueLogger.info(`This $$type is not stale`);
+      issueLogger.info(`This $$type is not marked stale`);
 
       const shouldIgnoreUpdates: boolean = new IgnoreUpdates(
         this.options,


### PR DESCRIPTION
**Description:**
The logging is really frustrating.

I created a run that covers 3 items (2 issues and 1 PR): https://github.com/jsoref/stale-bot-debug/actions/runs/5828506506/job/15806335430

* Some of the code understands that humans believe that PRs are not issues and that it's better to call the ambiguous set `items`, but a lot of the code doesn't.
* The overuse of quotation marks around an error made it look like it was the name of a label.
* Clarify that an item may not yet be marked as stale even though it may be marked as stale moments later.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
