### PR TITLE
BC: Do not run stale logic for newly stale objects

### DIFF
--- a/src/classes/issue.ts
+++ b/src/classes/issue.ts
@@ -21,7 +21,6 @@ export class Issue implements IIssue {
   readonly milestone?: IMilestone | null;
   readonly assignees: Assignee[];
   isStale: boolean;
-  markedStaleThisRun: boolean;
   operations = new Operations();
   private readonly _options: IIssuesProcessorOptions;
 
@@ -42,7 +41,6 @@ export class Issue implements IIssue {
     this.milestone = issue.milestone;
     this.assignees = issue.assignees || [];
     this.isStale = isLabeled(this, this.staleLabel);
-    this.markedStaleThisRun = false;
   }
 
   get isPullRequest(): boolean {


### PR DESCRIPTION
**Description:**

Simplify code for handling the transition from not-stale to stale. Do not run lots of code that makes no sense during this transition.

https://github.com/jsoref/stale-bot-debug/actions/runs/5828506506/job/15806335430#step:2:97

BEHAVIOR CHANGE:
This change will force action users to trigger two action runs if they want to both mark an item as stale and close it.

(You could technically write a workflow that called the action twice, it doesn't actually require two workflows.)

**Related issue:**
Add link to the related issue.

**Check list:**
- [x] Mark if documentation changes are required. -- _Possibly_. It depends on how good the documentation is. Based on how I encounter this action used in the real world (most projects are misconfigured and really don't understand what the actions does or how it works and certainly not how to achieve what they want), my bet is the documentation is sufficiently poor that it doesn't really, beyond a release note that this is a behavior change.
- [ ] Mark if tests were added or updated to cover the changes.
