### PR TITLE
fix: demote rate limit log to warn

### DIFF
--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -645,7 +645,7 @@ export class IssuesProcessor {
       const rateLimitResult = await this.client.rest.rateLimit.get();
       return new RateLimit(rateLimitResult.data.rate);
     } catch (error) {
-      logger.error(`Error when getting rateLimit: ${error.message}`);
+      logger.warn(`Error when getting rateLimit: ${error.message}`);
     }
   }
 


### PR DESCRIPTION
**Description:**

Hi there 👋🏼 
For GitHub enterprise, when GH Rate Limit is not enabled, we keep getting error logs although the workflow works as expected.

This PR demotes the error logs from `error` to `warn`.

![image](https://github.com/actions/stale/assets/30556071/f0127589-12bb-4897-8d8b-e953fcb2cc61)


**Related issue:**
None found

**Checklist:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
