### PR TITLE
Fix checking state cache (fix #1136), also switch to octokit methods

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1618,9 +1618,13 @@ const getOctokitClient = () => {
 const checkIfCacheExists = (cacheKey) => __awaiter(void 0, void 0, void 0, function* () {
     const client = getOctokitClient();
     try {
-        const issueResult = yield client.request(`/repos/${github_1.context.repo.owner}/${github_1.context.repo.repo}/actions/caches`);
-        const caches = issueResult.data['actions_caches'] || [];
-        return Boolean(caches.find(cache => cache['key'] === cacheKey));
+        const cachesResult = yield client.rest.actions.getActionsCacheList({
+            owner: github_1.context.repo.owner,
+            repo: github_1.context.repo.repo,
+            key: cacheKey, // prefix matching
+        });
+        const caches = cachesResult.data['actions_caches'] || [];
+        return caches.some(cache => cache['key'] === cacheKey);
     }
     catch (error) {
         core.debug(`Error checking if cache exist: ${error.message}`);
@@ -1631,8 +1635,11 @@ const resetCacheWithOctokit = (cacheKey) => __awaiter(void 0, void 0, void 0, fu
     const client = getOctokitClient();
     core.debug(`remove cache "${cacheKey}"`);
     try {
-        // TODO: replace with client.rest.
-        yield client.request(`DELETE /repos/${github_1.context.repo.owner}/${github_1.context.repo.repo}/actions/caches?key=${cacheKey}`);
+        yield client.rest.actions.deleteActionsCacheByKey({
+            owner: github_1.context.repo.owner,
+            repo: github_1.context.repo.repo,
+            key: cacheKey,
+        });
     }
     catch (error) {
         if (error.status) {

--- a/src/classes/state/state-cache-storage.ts
+++ b/src/classes/state/state-cache-storage.ts
@@ -33,12 +33,14 @@ const getOctokitClient = () => {
 const checkIfCacheExists = async (cacheKey: string): Promise<boolean> => {
   const client = getOctokitClient();
   try {
-    const issueResult = await client.request(
-      `/repos/${context.repo.owner}/${context.repo.repo}/actions/caches`
-    );
+    const cachesResult = await client.rest.actions.getActionsCacheList({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      key: cacheKey, // prefix matching
+    });
     const caches: Array<{key?: string}> =
-      issueResult.data['actions_caches'] || [];
-    return Boolean(caches.find(cache => cache['key'] === cacheKey));
+      cachesResult.data['actions_caches'] || [];
+    return caches.some(cache => cache['key'] === cacheKey);
   } catch (error) {
     core.debug(`Error checking if cache exist: ${error.message}`);
   }
@@ -48,10 +50,11 @@ const resetCacheWithOctokit = async (cacheKey: string): Promise<void> => {
   const client = getOctokitClient();
   core.debug(`remove cache "${cacheKey}"`);
   try {
-    // TODO: replace with client.rest.
-    await client.request(
-      `DELETE /repos/${context.repo.owner}/${context.repo.repo}/actions/caches?key=${cacheKey}`
-    );
+    await client.rest.actions.deleteActionsCacheByKey({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      key: cacheKey,
+    });
   } catch (error) {
     if (error.status) {
       core.warning(


### PR DESCRIPTION
**Description:**
This PR fixes #1136, also fixes a TODO comment about using octokit methods.

**Related issue:**
- #1136

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
  - These methods are not covered by existing tests, possibly because they interact with the GitHub APIs.
