### PR TITLE
sort issues by update instead of creation date

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -684,6 +684,7 @@ class IssuesProcessor {
                     state: 'open',
                     per_page: 100,
                     direction: this.options.ascending ? 'asc' : 'desc',
+                    sort: 'updated',
                     page
                 });
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCount(issueResult.data.length);

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -571,6 +571,7 @@ export class IssuesProcessor {
         state: 'open',
         per_page: 100,
         direction: this.options.ascending ? 'asc' : 'desc',
+        sort: 'updated',
         page
       });
       this.statistics?.incrementFetchedItemsCount(issueResult.data.length);


### PR DESCRIPTION
**Description:**
When processing a limited number of issues/pull requests, it is more efficient to process the ones with the older update first, because they are the ones with the highest chance of being stale.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
