### PR TITLE
Add cache-prefixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This can be achieved with the following [configuration in the action](https://do
 
 ```yaml
 permissions:
+  actions: write # for caching state
   contents: write # only for delete-branch option
   issues: write
   pull-requests: write
@@ -97,6 +98,7 @@ Every argument is optional.
 | [ignore-issue-updates](#ignore-issue-updates)                       | Override [ignore-updates](#ignore-updates) for issues only                  |                       |
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
 | [include-only-assigned](#include-only-assigned)                     | Process only assigned issues                                                | `false`               |
+| [cache-prefix](#cache-prefix)                                       | Add a prefix to the stored cache                                            |                       |
 
 ### List of output options
 
@@ -546,6 +548,11 @@ Default value: unset
 If set to `true`, only the issues or the pull requests with an assignee will be marked as stale automatically.
 
 Default value: `false`
+
+#### cache-prefix
+
+Beneficial so the action has a more unique cahce key. Useful when calling this action multiple times, independent of each other.
+An example for usage would be closing all PRs with `x` label after 7 days in one action and closing all PRs except for `x` label after 10 days in another.
 
 ### Usage
 

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -55,5 +55,6 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   ignorePrUpdates: undefined,
   exemptDraftPr: false,
   closeIssueReason: 'not_planned',
-  includeOnlyAssigned: false
+  includeOnlyAssigned: false,
+  cachePrefix: ''
 });

--- a/action.yml
+++ b/action.yml
@@ -204,6 +204,10 @@ inputs:
     description: 'Only the issues or the pull requests with an assignee will be marked as stale automatically.'
     default: 'false'
     required: false
+  cache-prefix:
+    description: 'Add a prefix to the stored cache. Useful when using this action multiple times with different params.'
+    default: ''
+    required: false
 outputs:
   closed-issues-prs:
     description: 'List of all closed issues and pull requests.'

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -64,7 +64,8 @@ describe('Issue', (): void => {
       ignorePrUpdates: undefined,
       exemptDraftPr: false,
       closeIssueReason: '',
-      includeOnlyAssigned: false
+      includeOnlyAssigned: false,
+      cachePrefix: ''
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/classes/state/state-cache-storage.ts
+++ b/src/classes/state/state-cache-storage.ts
@@ -6,6 +6,7 @@ import * as core from '@actions/core';
 import {context, getOctokit} from '@actions/github';
 import {retry as octokitRetry} from '@octokit/plugin-retry';
 import * as cache from '@actions/cache';
+import {IIssuesProcessorOptions} from '../../interfaces/issues-processor-options';
 
 const CACHE_KEY = '_state';
 const STATE_FILE = 'state.txt';
@@ -65,15 +66,26 @@ const resetCacheWithOctokit = async (cacheKey: string): Promise<void> => {
   }
 };
 export class StateCacheStorage implements IStateStorage {
+  /**
+   * @private don't mutate in the debug mode
+   */
+  private readonly statePrefix: string;
+
+  constructor(options: IIssuesProcessorOptions) {
+    this.statePrefix = options.cachePrefix;
+  }
+
   async save(serializedState: string): Promise<void> {
     const tmpDir = mkTempDir();
-    const filePath = path.join(tmpDir, STATE_FILE);
+    const stateFile = `${this.statePrefix}_${STATE_FILE}`;
+    const filePath = path.join(tmpDir, stateFile);
     fs.writeFileSync(filePath, serializedState);
 
     try {
-      const cacheExists = await checkIfCacheExists(CACHE_KEY);
+      const cacheKey = `${this.statePrefix}${CACHE_KEY}`;
+      const cacheExists = await checkIfCacheExists(cacheKey);
       if (cacheExists) {
-        await resetCacheWithOctokit(CACHE_KEY);
+        await resetCacheWithOctokit(cacheKey);
       }
       const fileSize = fs.statSync(filePath).size;
 
@@ -82,7 +94,7 @@ export class StateCacheStorage implements IStateStorage {
         return;
       }
 
-      await cache.saveCache([path.dirname(filePath)], CACHE_KEY);
+      await cache.saveCache([path.dirname(filePath)], cacheKey);
     } catch (error) {
       core.warning(
         `Saving the state was not successful due to "${
@@ -96,10 +108,12 @@ export class StateCacheStorage implements IStateStorage {
 
   async restore(): Promise<string> {
     const tmpDir = mkTempDir();
-    const filePath = path.join(tmpDir, STATE_FILE);
+    const stateFile = `${this.statePrefix}_${STATE_FILE}`;
+    const filePath = path.join(tmpDir, stateFile);
     unlinkSafely(filePath);
     try {
-      const cacheExists = await checkIfCacheExists(CACHE_KEY);
+      const cacheKey = `${this.statePrefix}${CACHE_KEY}`;
+      const cacheExists = await checkIfCacheExists(cacheKey);
       if (!cacheExists) {
         core.info(
           'The saved state was not found, the process starts from the first issue.'
@@ -107,7 +121,7 @@ export class StateCacheStorage implements IStateStorage {
         return '';
       }
 
-      await cache.restoreCache([path.dirname(filePath)], CACHE_KEY);
+      await cache.restoreCache([path.dirname(filePath)], cacheKey);
 
       if (!fs.existsSync(filePath)) {
         core.warning(
@@ -115,7 +129,7 @@ export class StateCacheStorage implements IStateStorage {
         );
         return '';
       }
-      return fs.readFileSync(path.join(tmpDir, STATE_FILE), {
+      return fs.readFileSync(path.join(tmpDir, stateFile), {
         encoding: 'utf8'
       });
     } catch (error) {

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -48,5 +48,6 @@ export enum Option {
   IgnoreIssueUpdates = 'ignore-issue-updates',
   IgnorePrUpdates = 'ignore-pr-updates',
   ExemptDraftPr = 'exempt-draft-pr',
-  CloseIssueReason = 'close-issue-reason'
+  CloseIssueReason = 'close-issue-reason',
+  CachePrefix = 'cache-prefix'
 }

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -54,4 +54,5 @@ export interface IIssuesProcessorOptions {
   exemptDraftPr: boolean;
   closeIssueReason: string;
   includeOnlyAssigned: boolean;
+  cachePrefix: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,8 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
     exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
     closeIssueReason: core.getInput('close-issue-reason'),
-    includeOnlyAssigned: core.getInput('include-only-assigned') === 'true'
+    includeOnlyAssigned: core.getInput('include-only-assigned') === 'true',
+    cachePrefix: core.getInput('cache-prefix')
   };
 
   for (const numberInput of ['days-before-stale']) {

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -4,6 +4,6 @@ import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
 import {StateCacheStorage} from '../classes/state/state-cache-storage';
 
 export const getStateInstance = (options: IIssuesProcessorOptions): IState => {
-  const storage = new StateCacheStorage();
+  const storage = new StateCacheStorage(options);
   return new State(storage, options);
 };


### PR DESCRIPTION
**Description:**
This changes allow the state saved to the global action cache to be stored with a prefix. Useful as `_state` is not a unique name and multiple workflows could save the cache as `_state`. Also useful as you currently cannot use this action twice for independent runs as the runs would pick up the same state. With this change, it is possible to have one run close all PRs with label `x` after 7 days and another run close all PRs except those with label `x` after 10 days.

Also updated the README.md to show proper permissions needed.

**Related issue:**
https://github.com/actions/stale/issues/1137

Please also look into merging https://github.com/actions/stale/pull/1152 as this isn't necessarily useful if caching isn't 100% fixed.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
