### PR TITLE
Allow the processing of locked issues and pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Every argument is optional.
 | [ignore-issue-updates](#ignore-issue-updates)                       | Override [ignore-updates](#ignore-updates) for issues only                  |                       |
 | [ignore-pr-updates](#ignore-pr-updates)                             | Override [ignore-updates](#ignore-updates) for PRs only                     |                       |
 | [include-only-assigned](#include-only-assigned)                     | Process only assigned issues                                                | `false`               |
+| [exempt-locked](#exempt-locked)                                     | Issues and pull requests that are locked will not be marked as stale.       | `true`                |
 
 ### List of output options
 
@@ -546,6 +547,16 @@ Default value: unset
 If set to `true`, only the issues or the pull requests with an assignee will be marked as stale automatically.
 
 Default value: `false`
+
+#### exempt-locked
+
+If set to `false` issues or pull requests that are locked will be marked as
+stale automatically. If you process locked issues and pull requests and want to
+add a closing message the default repo-token will not be sufficient. For that
+you will have to use a PAT which has write access, is repository owner or
+collaborator.
+
+Default value: `true`
 
 ### Usage
 

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -55,5 +55,6 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   ignorePrUpdates: undefined,
   exemptDraftPr: false,
   closeIssueReason: 'not_planned',
-  includeOnlyAssigned: false
+  includeOnlyAssigned: false,
+  exemptLocked: true
 });

--- a/action.yml
+++ b/action.yml
@@ -204,6 +204,10 @@ inputs:
     description: 'Only the issues or the pull requests with an assignee will be marked as stale automatically.'
     default: 'false'
     required: false
+  exempt-locked:
+    description: 'Issues and pull requests that are locked will not be marked as stale.'
+    default: 'true'
+    required: false
 outputs:
   closed-issues-prs:
     description: 'List of all closed issues and pull requests.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -495,7 +495,7 @@ class IssuesProcessor {
                 IssuesProcessor._endIssueProcessing(issue);
                 return; // Don't process closed issues
             }
-            if (issue.locked) {
+            if (issue.locked && this.options.exemptLocked) {
                 issueLogger.info(`Skipping this $$type because it is locked`);
                 IssuesProcessor._endIssueProcessing(issue);
                 return; // Don't process locked issues
@@ -2567,7 +2567,8 @@ function _getAndValidateArgs() {
         ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
         exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
         closeIssueReason: core.getInput('close-issue-reason'),
-        includeOnlyAssigned: core.getInput('include-only-assigned') === 'true'
+        includeOnlyAssigned: core.getInput('include-only-assigned') === 'true',
+        exemptLocked: core.getInput('exempt-locked') === 'true'
     };
     for (const numberInput of ['days-before-stale']) {
         if (isNaN(parseFloat(core.getInput(numberInput)))) {

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -64,7 +64,8 @@ describe('Issue', (): void => {
       ignorePrUpdates: undefined,
       exemptDraftPr: false,
       closeIssueReason: '',
-      includeOnlyAssigned: false
+      includeOnlyAssigned: false,
+      exemptLocked: true
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -237,7 +237,7 @@ export class IssuesProcessor {
       return; // Don't process closed issues
     }
 
-    if (issue.locked) {
+    if (issue.locked && this.options.exemptLocked) {
       issueLogger.info(`Skipping this $$type because it is locked`);
       IssuesProcessor._endIssueProcessing(issue);
       return; // Don't process locked issues
@@ -1196,7 +1196,9 @@ export class IssuesProcessor {
     const issueLogger: IssueLogger = new IssueLogger(issue);
 
     issueLogger.info(
-      `The $$type is not closed nor locked. Trying to remove the close label...`
+      `The $$type is not closed${
+        this.options.exemptLocked ? ' nor locked' : ''
+      }. Trying to remove the close label...`
     );
 
     if (!closeLabel) {

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -54,4 +54,5 @@ export interface IIssuesProcessorOptions {
   exemptDraftPr: boolean;
   closeIssueReason: string;
   includeOnlyAssigned: boolean;
+  exemptLocked: boolean;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,8 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
     exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
     closeIssueReason: core.getInput('close-issue-reason'),
-    includeOnlyAssigned: core.getInput('include-only-assigned') === 'true'
+    includeOnlyAssigned: core.getInput('include-only-assigned') === 'true',
+    exemptLocked: core.getInput('exempt-locked') === 'true'
   };
 
   for (const numberInput of ['days-before-stale']) {


### PR DESCRIPTION
**Description:**

I currently have a use case which requires the stale action to process locked issues and pull requests. This PR gives users of the stale action the possibility to opt in for the processing of locked PRs and issues. The documentation also informs the user that they require a PAT with more access if they want to add a closing message on a locked PR or issue.

**Related issue:**

- https://github.com/actions/stale/issues/51
- https://github.com/probot/stale/issues/25#issuecomment-300806999

Extends functionality without breaking the issues above.

**Check list:**

- [X] Mark if documentation changes are required.
- [X] Mark if tests were added or updated to cover the changes.
