### PR TITLE
Updating removedLabelIssues only when the label was successfully removed

### DIFF
--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -1016,7 +1016,6 @@ export class IssuesProcessor {
         isSubStep ? LoggerService.white('├── ') : ''
       }Removing the label "${LoggerService.cyan(label)}" from this $$type...`
     );
-    this.removedLabelIssues.push(issue);
 
     try {
       this._consumeIssueOperation(issue);
@@ -1036,6 +1035,8 @@ export class IssuesProcessor {
           isSubStep ? LoggerService.white('└── ') : ''
         }The label "${LoggerService.cyan(label)}" was removed`
       );
+
+      this.removedLabelIssues.push(issue);
     } catch (error) {
       issueLogger.error(
         `${


### PR DESCRIPTION
**Description:**
While debugging the following issue, I noticed I can't reproduce the error.
I then noticed the success message is logged before the actual call to Github's API.
This PR fixed this.

**Related issue:**
https://github.com/actions/stale/issues/1165

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
