### PR TITLE
do not attempt to delete existing cache

### DIFF
--- a/src/classes/state/state-cache-storage.ts
+++ b/src/classes/state/state-cache-storage.ts
@@ -44,26 +44,6 @@ const checkIfCacheExists = async (cacheKey: string): Promise<boolean> => {
   }
   return false;
 };
-const resetCacheWithOctokit = async (cacheKey: string): Promise<void> => {
-  const client = getOctokitClient();
-  core.debug(`remove cache "${cacheKey}"`);
-  try {
-    // TODO: replace with client.rest.
-    await client.request(
-      `DELETE /repos/${context.repo.owner}/${context.repo.repo}/actions/caches?key=${cacheKey}`
-    );
-  } catch (error) {
-    if (error.status) {
-      core.warning(
-        `Error delete ${cacheKey}: [${error.status}] ${
-          error.message || 'Unknown reason'
-        }`
-      );
-    } else {
-      throw error;
-    }
-  }
-};
 export class StateCacheStorage implements IStateStorage {
   async save(serializedState: string): Promise<void> {
     const tmpDir = mkTempDir();
@@ -71,10 +51,6 @@ export class StateCacheStorage implements IStateStorage {
     fs.writeFileSync(filePath, serializedState);
 
     try {
-      const cacheExists = await checkIfCacheExists(CACHE_KEY);
-      if (cacheExists) {
-        await resetCacheWithOctokit(CACHE_KEY);
-      }
       const fileSize = fs.statSync(filePath).size;
 
       if (fileSize === 0) {

--- a/src/classes/state/state-cache-storage.ts
+++ b/src/classes/state/state-cache-storage.ts
@@ -54,7 +54,10 @@ export class StateCacheStorage implements IStateStorage {
     const filePath = path.join(tmpDir, STATE_FILE);
     unlinkSafely(filePath);
     try {
-      const cacheExists = await cache.restoreCache([path.dirname(filePath)], CACHE_KEY);
+      const cacheExists = await cache.restoreCache(
+        [path.dirname(filePath)],
+        CACHE_KEY
+      );
       if (!cacheExists) {
         core.info(
           'The saved state was not found, the process starts from the first issue.'


### PR DESCRIPTION
**Description:**
I don't think it's necessary to delete existing cache before overwriting it. https://github.com/actions/cache does not seem to do it. The problem with deleting a cache entry is that it requires to give `actions: write` permissions, which means the workflow has [all these permissions](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28#repository-permissions-for-actions) and this is way too much, and not acceptable for a lot of projects.

Also, do not check if cache exists during restore. It introduces a TOCTOU issue, and is not needed because `restoreCache` returns `undefined` if the cache does not exist, cf https://github.com/actions/toolkit/tree/main/packages/cache

**Related issue:**
fixes https://github.com/actions/stale/issues/1159
fixes https://github.com/actions/stale/issues/1133
fixes https://github.com/actions/stale/issues/1131


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
