### PR TITLE
fix: warning if rate limit is disabled

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -744,10 +744,30 @@ class IssuesProcessor {
             const logger = new logger_1.Logger();
             try {
                 const rateLimitResult = yield this.client.rest.rateLimit.get();
-                return new rate_limit_1.RateLimit(rateLimitResult.data.rate);
+                if (rateLimitResult.data.rate) {
+                    return new rate_limit_1.RateLimit(rateLimitResult.data.rate);
+                }
+                else {
+                    logger.warning('Rate limit is disabled or not available.');
+                    return null;
+                }
             }
             catch (error) {
-                logger.error(`Error when getting rateLimit: ${error.message}`);
+                if (error instanceof Error) {
+                    if (error.message.includes('Not Found') ||
+                        error.message.includes('404')) {
+                        logger.warning('Rate limit endpoint not found. Rate limiting may be disabled.');
+                        return null;
+                    }
+                    else {
+                        logger.error(`Error when getting rateLimit: ${error.message}`);
+                        throw error;
+                    }
+                }
+                else {
+                    logger.error('An unknown error occurred when getting rateLimit');
+                    throw error;
+                }
             }
         });
     }


### PR DESCRIPTION
**Description:**
This will add a warning if rate limit is disabled (for GitHub Enterprises use cases).
Today we got an error message when running our workflow, we should instead get a warning since this is a feature from GitHub Enterprise and not an error. 

I'm making it as a warning because it's best practices to have it enabled so we could at least inform users that's disabled.

**Related issue:**
#1156 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
