### PR TITLE
bump undici to 5.28.5

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -76525,6 +76525,14 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(9830)
 const { File: UndiciFile } = __nccwpck_require__(8511)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(685)
 
+let random
+try {
+  const crypto = __nccwpck_require__(6005)
+  random = (max) => crypto.randomInt(0, max)
+} catch {
+  random = (max) => Math.floor(Math.random(max))
+}
+
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -76610,7 +76618,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -97768,6 +97776,14 @@ module.exports = require("https");
 
 "use strict";
 module.exports = require("net");
+
+/***/ }),
+
+/***/ 6005:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:crypto");
 
 /***/ }),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7567,9 +7567,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },


### PR DESCRIPTION
fixes a vulnerability https://github.com/ericLemanissier/stale/security/dependabot/5


Updates `undici` from 5.28.4 to 5.28.5
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/nodejs/undici/releases">undici's releases</a>.</em></p>
<blockquote>
<h2>v5.28.5</h2>
<h1>⚠️ Security Release ⚠️</h1>
<p>Fixes CVE CVE-2025-22150 <a href="https://github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975">https://github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975</a> (embargoed until 22-01-2025).</p>
<p><strong>Full Changelog</strong>: <a href="https://github.com/nodejs/undici/compare/v5.28.4...v5.28.5">https://github.com/nodejs/undici/compare/v5.28.4...v5.28.5</a></p>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/nodejs/undici/commit/6139ed2e0c787853243de58ef7c4301b26ca66f2"><code>6139ed2</code></a> Bumped v5.28.5</li>
<li><a href="https://github.com/nodejs/undici/commit/711e20772764c29f6622ddc937c63b6eefdf07d0"><code>711e207</code></a> Backport of c2d78cd</li>
<li>See full diff in <a href="https://github.com/nodejs/undici/compare/v5.28.4...v5.28.5">compare view</a></li>
</ul>
</details>