### PR TITLE
Allow option to exclude specific weekdays from total time

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Every argument is optional.
 | [ascending](#ascending)                                             | Order to get issues/PRs                                                     | `false`               |
 | [start-date](#start-date)                                           | Skip stale action for issues/PRs created before it                          |                       |
 | [delete-branch](#delete-branch)                                     | Delete branch after closing a stale PR                                      | `false`               |
+| [exclude-weekdays](#exclude-weekdays)                               | Weekdays to exclude when calculating elapsed days                           |                       |
 | [exempt-milestones](#exempt-milestones)                             | Milestones on issues/PRs exempted from stale                                |                       |
 | [exempt-issue-milestones](#exempt-issue-milestones)                 | Override [exempt-milestones](#exempt-milestones) for issues only            |                       |
 | [exempt-pr-milestones](#exempt-pr-milestones)                       | Override [exempt-milestones](#exempt-milestones) for PRs only               |                       |
@@ -548,6 +549,15 @@ Default value: unset
 #### ignore-pr-updates
 
 Useful to override [ignore-updates](#ignore-updates) but only to ignore the updates for the pull requests.
+
+Default value: unset
+
+#### exclude-weekdays
+
+A comma separated list of weekdays (0-6, where 0 is Sunday and 6 is Saturday) to exclude when calculating elapsed days.
+This is useful when you want to count only business days for stale calculations.
+
+For example, to exclude weekends, set this to `0,6`.
 
 Default value: unset
 

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -56,5 +56,6 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   ignorePrUpdates: undefined,
   exemptDraftPr: false,
   closeIssueReason: 'not_planned',
-  includeOnlyAssigned: false
+  includeOnlyAssigned: false,
+  excludeWeekdays: []
 });

--- a/action.yml
+++ b/action.yml
@@ -212,6 +212,10 @@ inputs:
     description: 'Only issues with a matching type are processed as stale/closed. Defaults to `[]` (disabled) and can be a comma-separated list of issue types.'
     default: ''
     required: false
+  exclude-weekdays:
+    description: 'Comma-separated list of weekdays to exclude from elapsed days calculation (0=Sunday, 6=Saturday)'
+    required: false
+    default: ''
 outputs:
   closed-issues-prs:
     description: 'List of all closed issues and pull requests.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -375,6 +375,7 @@ const is_valid_date_1 = __nccwpck_require__(891);
 const is_boolean_1 = __nccwpck_require__(8236);
 const is_labeled_1 = __nccwpck_require__(6792);
 const clean_label_1 = __nccwpck_require__(7752);
+const elapsed_millis_excluding_days_1 = __nccwpck_require__(4101);
 const should_mark_when_stale_1 = __nccwpck_require__(2461);
 const words_to_list_1 = __nccwpck_require__(1883);
 const assignees_1 = __nccwpck_require__(7236);
@@ -394,9 +395,9 @@ const get_sort_field_1 = __nccwpck_require__(9551);
  * Handle processing of issues for staleness/closure.
  */
 class IssuesProcessor {
-    static _updatedSince(timestamp, num_days) {
-        const daysInMillis = 1000 * 60 * 60 * 24 * num_days;
-        const millisSinceLastUpdated = new Date().getTime() - new Date(timestamp).getTime();
+    static _updatedSince(timestamp, numDays, excludeWeekdays) {
+        const daysInMillis = 1000 * 60 * 60 * 24 * numDays;
+        const millisSinceLastUpdated = (0, elapsed_millis_excluding_days_1.elapsedMillisExcludingDays)(new Date(timestamp), new Date(), excludeWeekdays);
         return millisSinceLastUpdated <= daysInMillis;
     }
     static _endIssueProcessing(issue) {
@@ -629,11 +630,11 @@ class IssuesProcessor {
                 let shouldBeStale;
                 // Ignore the last update and only use the creation date
                 if (shouldIgnoreUpdates) {
-                    shouldBeStale = !IssuesProcessor._updatedSince(issue.created_at, daysBeforeStale);
+                    shouldBeStale = !IssuesProcessor._updatedSince(issue.created_at, daysBeforeStale, this.options.excludeWeekdays);
                 }
                 // Use the last update to check if we need to stale
                 else {
-                    shouldBeStale = !IssuesProcessor._updatedSince(issue.updated_at, daysBeforeStale);
+                    shouldBeStale = !IssuesProcessor._updatedSince(issue.updated_at, daysBeforeStale, this.options.excludeWeekdays);
                 }
                 if (shouldBeStale) {
                     if (shouldIgnoreUpdates) {
@@ -823,7 +824,7 @@ class IssuesProcessor {
             if (daysBeforeClose < 0) {
                 return; // Nothing to do because we aren't closing stale issues
             }
-            const issueHasUpdateInCloseWindow = IssuesProcessor._updatedSince(issue.updated_at, daysBeforeClose);
+            const issueHasUpdateInCloseWindow = IssuesProcessor._updatedSince(issue.updated_at, daysBeforeClose, this.options.excludeWeekdays);
             issueLogger.info(`$$type has been updated in the last ${daysBeforeClose} days: ${logger_service_1.LoggerService.cyan(issueHasUpdateInCloseWindow)}`);
             if (!issueHasCommentsSinceStale && !issueHasUpdateInCloseWindow) {
                 issueLogger.info(`Closing $$type because it was last updated on: ${logger_service_1.LoggerService.cyan(issue.updated_at)}`);
@@ -2365,6 +2366,51 @@ exports.isValidDate = isValidDate;
 
 /***/ }),
 
+/***/ 4101:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.elapsedMillisExcludingDays = void 0;
+const DAY = 1000 * 60 * 60 * 24;
+function startOfDay(date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
+}
+function countWeekdaysBetweenDates(start, end, weekdays) {
+    const totalDays = Math.floor((end.getTime() - start.getTime()) / DAY);
+    const startDayOfWeek = start.getDay();
+    const weekdaysMap = new Set(weekdays);
+    let count = 0;
+    for (let i = 0; i < totalDays; i++) {
+        const currentDay = (startDayOfWeek + i) % 7;
+        if (weekdaysMap.has(currentDay)) {
+            count++;
+        }
+    }
+    return count;
+}
+const elapsedMillisExcludingDays = (from, to, excludeWeekdays) => {
+    let elapsedMillis = to.getTime() - from.getTime();
+    if (excludeWeekdays.length > 0) {
+        const startOfNextDayFrom = startOfDay(new Date(from.getTime() + DAY));
+        const startOfDayTo = startOfDay(to);
+        if (excludeWeekdays.includes(from.getDay())) {
+            elapsedMillis -= startOfNextDayFrom.getTime() - from.getTime();
+        }
+        if (excludeWeekdays.includes(to.getDay())) {
+            elapsedMillis -= to.getTime() - startOfDayTo.getTime();
+        }
+        const excludeWeekdaysCount = countWeekdaysBetweenDates(startOfNextDayFrom, startOfDayTo, excludeWeekdays);
+        elapsedMillis -= excludeWeekdaysCount * DAY;
+    }
+    return elapsedMillis;
+};
+exports.elapsedMillisExcludingDays = elapsedMillisExcludingDays;
+
+
+/***/ }),
+
 /***/ 9551:
 /***/ ((__unused_webpack_module, exports) => {
 
@@ -2618,7 +2664,13 @@ function _getAndValidateArgs() {
         exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
         closeIssueReason: core.getInput('close-issue-reason'),
         includeOnlyAssigned: core.getInput('include-only-assigned') === 'true',
-        onlyIssueTypes: core.getInput('only-issue-types')
+        onlyIssueTypes: core.getInput('only-issue-types'),
+        excludeWeekdays: core.getInput('exclude-weekdays')
+            ? core
+                .getInput('exclude-weekdays')
+                .split(',')
+                .map(day => parseInt(day.trim(), 10))
+            : []
     };
     for (const numberInput of ['days-before-stale']) {
         if (isNaN(parseFloat(core.getInput(numberInput)))) {
@@ -2647,6 +2699,13 @@ function _getAndValidateArgs() {
     const validCloseReasons = ['', 'completed', 'not_planned'];
     if (!validCloseReasons.includes(args.closeIssueReason)) {
         const errorMessage = `Unrecognized close-issue-reason "${args.closeIssueReason}", valid values are: ${validCloseReasons.filter(Boolean).join(', ')}`;
+        core.setFailed(errorMessage);
+        throw new Error(errorMessage);
+    }
+    // Validate weekdays
+    if (args.excludeWeekdays &&
+        args.excludeWeekdays.some(day => isNaN(day) || day < 0 || day > 6)) {
+        const errorMessage = 'Option "exclude-weekdays" must be comma-separated integers between 0 (Sunday) and 6 (Saturday)';
         core.setFailed(errorMessage);
         throw new Error(errorMessage);
     }

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -65,7 +65,8 @@ describe('Issue', (): void => {
       ignorePrUpdates: undefined,
       exemptDraftPr: false,
       closeIssueReason: '',
-      includeOnlyAssigned: false
+      includeOnlyAssigned: false,
+      excludeWeekdays: []
     };
     issueInterface = {
       title: 'dummy-title',

--- a/src/functions/elapsed-millis-excluding-days.spec.ts
+++ b/src/functions/elapsed-millis-excluding-days.spec.ts
@@ -1,0 +1,71 @@
+import {elapsedMillisExcludingDays} from './elapsed-millis-excluding-days';
+
+describe('elapsedMillisExcludingDays', () => {
+  const HOUR = 1000 * 60 * 60;
+  const DAY = HOUR * 24;
+
+  it('calculates elapsed days when no weekdays are excluded', () => {
+    const from = new Date();
+    const lessThan = new Date(from.getTime() - 1);
+    const equal = from;
+    const greaterThan = new Date(from.getTime() + 1);
+
+    expect(elapsedMillisExcludingDays(from, lessThan, [])).toEqual(-1);
+    expect(elapsedMillisExcludingDays(from, equal, [])).toEqual(0);
+    expect(elapsedMillisExcludingDays(from, greaterThan, [])).toEqual(1);
+  });
+
+  it('calculates elapsed days with specified weekdays excluded', () => {
+    const date = new Date('2025-03-03 09:00:00'); // Monday
+
+    const tomorrow = new Date('2025-03-04 09:00:00');
+    expect(elapsedMillisExcludingDays(date, tomorrow, [])).toEqual(DAY);
+    expect(elapsedMillisExcludingDays(date, tomorrow, [1])).toEqual(9 * HOUR);
+
+    const dayAfterTomorrow = new Date('2025-03-05 10:00:00');
+    const full = 2 * DAY + HOUR;
+    expect(elapsedMillisExcludingDays(date, dayAfterTomorrow, [])).toEqual(
+      full
+    );
+    expect(elapsedMillisExcludingDays(date, dayAfterTomorrow, [0])).toEqual(
+      full
+    );
+    expect(elapsedMillisExcludingDays(date, dayAfterTomorrow, [1])).toEqual(
+      full - 15 * HOUR
+    );
+    expect(elapsedMillisExcludingDays(date, dayAfterTomorrow, [2])).toEqual(
+      full - DAY
+    );
+    expect(elapsedMillisExcludingDays(date, dayAfterTomorrow, [3])).toEqual(
+      full - 10 * HOUR
+    );
+    expect(elapsedMillisExcludingDays(date, dayAfterTomorrow, [4])).toEqual(
+      full
+    );
+    expect(elapsedMillisExcludingDays(date, dayAfterTomorrow, [1, 2])).toEqual(
+      10 * HOUR
+    );
+    expect(elapsedMillisExcludingDays(date, dayAfterTomorrow, [2, 3])).toEqual(
+      15 * HOUR
+    );
+  });
+
+  it('handles week spanning periods correctly', () => {
+    const friday = new Date('2025-03-07 09:00:00');
+    const nextMonday = new Date('2025-03-10 09:00:00');
+    expect(elapsedMillisExcludingDays(friday, nextMonday, [0, 6])).toEqual(DAY);
+  });
+
+  it('handles long periods with multiple weeks', () => {
+    const start = new Date('2025-03-03 09:00:00');
+    const twoWeeksLater = new Date('2025-03-17 09:00:00');
+    expect(elapsedMillisExcludingDays(start, twoWeeksLater, [0, 6])).toEqual(
+      10 * DAY
+    );
+
+    const lessThanTwoWeeksLater = new Date('2025-03-17 08:59:59');
+    expect(
+      elapsedMillisExcludingDays(start, lessThanTwoWeeksLater, [0, 6])
+    ).toEqual(10 * DAY - 1000);
+  });
+});

--- a/src/functions/elapsed-millis-excluding-days.ts
+++ b/src/functions/elapsed-millis-excluding-days.ts
@@ -1,0 +1,60 @@
+const DAY = 1000 * 60 * 60 * 24;
+
+function startOfDay(date: Date): Date {
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    0,
+    0,
+    0,
+    0
+  );
+}
+
+function countWeekdaysBetweenDates(start: Date, end: Date, weekdays: number[]) {
+  const totalDays = Math.floor((end.getTime() - start.getTime()) / DAY);
+  const startDayOfWeek = start.getDay();
+  const weekdaysMap = new Set(weekdays);
+
+  let count = 0;
+  for (let i = 0; i < totalDays; i++) {
+    const currentDay = (startDayOfWeek + i) % 7;
+    if (weekdaysMap.has(currentDay)) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+export const elapsedMillisExcludingDays = (
+  from: Date,
+  to: Date,
+  excludeWeekdays: number[]
+): number => {
+  let elapsedMillis = to.getTime() - from.getTime();
+
+  if (excludeWeekdays.length > 0) {
+    const startOfNextDayFrom = startOfDay(new Date(from.getTime() + DAY));
+    const startOfDayTo = startOfDay(to);
+
+    if (excludeWeekdays.includes(from.getDay())) {
+      elapsedMillis -= startOfNextDayFrom.getTime() - from.getTime();
+    }
+
+    if (excludeWeekdays.includes(to.getDay())) {
+      elapsedMillis -= to.getTime() - startOfDayTo.getTime();
+    }
+
+    const excludeWeekdaysCount = countWeekdaysBetweenDates(
+      startOfNextDayFrom,
+      startOfDayTo,
+      excludeWeekdays
+    );
+
+    elapsedMillis -= excludeWeekdaysCount * DAY;
+  }
+
+  return elapsedMillis;
+};

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -56,4 +56,5 @@ export interface IIssuesProcessorOptions {
   closeIssueReason: string;
   includeOnlyAssigned: boolean;
   onlyIssueTypes?: string;
+  excludeWeekdays: number[];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,14 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
     closeIssueReason: core.getInput('close-issue-reason'),
     includeOnlyAssigned: core.getInput('include-only-assigned') === 'true',
-    onlyIssueTypes: core.getInput('only-issue-types')
+    onlyIssueTypes: core.getInput('only-issue-types'),
+    excludeWeekdays:
+      core.getInput('exclude-weekdays')
+        ? core
+          .getInput('exclude-weekdays')
+          .split(',')
+          .map(day => parseInt(day.trim(), 10))
+        : []
   };
 
   for (const numberInput of ['days-before-stale']) {
@@ -160,6 +167,17 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     const errorMessage = `Unrecognized close-issue-reason "${
       args.closeIssueReason
     }", valid values are: ${validCloseReasons.filter(Boolean).join(', ')}`;
+    core.setFailed(errorMessage);
+    throw new Error(errorMessage);
+  }
+
+  // Validate weekdays
+  if (
+    args.excludeWeekdays &&
+    args.excludeWeekdays.some(day => isNaN(day) || day < 0 || day > 6)
+  ) {
+    const errorMessage =
+      'Option "exclude-weekdays" must be comma-separated integers between 0 (Sunday) and 6 (Saturday)';
     core.setFailed(errorMessage);
     throw new Error(errorMessage);
   }


### PR DESCRIPTION
**Description:**


Add support for excluding specific weekdays when calculating elapsed days for stale issues and PRs. This is particularly useful for organizations that want to consider only business days.

- Add new `exclude-weekdays` option to specify which days to exclude (0-6, where 0 is Sunday)
- Implement weekday exclusion logic in elapsed days calculation
- Add tests to verify business days calculation

```yaml
- uses: actions/stale@v9
  with:
    days-before-stale: 5
    days-before-close: 2
    exclude-weekdays: '0,6'  # Exclude weekends
```

**Related issue:**

Fixed #564

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
