### PR TITLE
Fix actions/stale#1227

### DIFF
--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -645,6 +645,11 @@ export class IssuesProcessor {
       const rateLimitResult = await this.client.rest.rateLimit.get();
       return new RateLimit(rateLimitResult.data.rate);
     } catch (error) {
+      if (error.status === 404) {
+        // Rate limiting is not enabled, due to this being GitHub Enterprise Server
+        // and not GitHub Cloud. Ignore the error and carry on.
+        return;
+      }
       logger.error(`Error when getting rateLimit: ${error.message}`);
     }
   }


### PR DESCRIPTION
**Description:**
Fixes #1227. GitHub Enterprise Server has no rate limits by default, and returns status 404 from the rate_limit endpoint.

**Related issue:**
#1227 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
