### PR TITLE
Introducing sort-issues-by option

### DIFF
--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -32,6 +32,7 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   removeIssueStaleWhenUpdated: undefined,
   removePrStaleWhenUpdated: undefined,
   ascending: false,
+  sortIssuesBy: 'created',
   deleteBranch: false,
   startDate: '',
   exemptMilestones: '',

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,10 @@ inputs:
     description: 'The order to get issues or pull requests. Defaults to false, which is descending.'
     default: 'false'
     required: false
+  sort-issues-by:
+    description: 'What to sort results by'
+    default: 'created'
+    required: false
   delete-branch:
     description: 'Delete the git branch after closing a stale pull request.'
     default: 'false'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,3 @@
-const { sort } = require('semver');
-
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
@@ -686,12 +684,11 @@ class IssuesProcessor {
                     state: 'open',
                     per_page: 100,
                     direction: this.options.ascending ? 'asc' : 'desc',
-                    sort:
-                    this.options.sortIssuesBy === 'updated'
-                      ? 'updated'
-                      : this.options.sortIssuesBy === 'comments'
-                      ? 'comments'
-                      : 'created',
+                    sort: this.options.sortIssuesBy === 'updated'
+                        ? 'updated'
+                        : this.options.sortIssuesBy === 'comments'
+                            ? 'comments'
+                            : 'created',
                     page
                 });
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCount(issueResult.data.length);
@@ -2207,7 +2204,7 @@ var Option;
     Option["RemovePrStaleWhenUpdated"] = "remove-pr-stale-when-updated";
     Option["DebugOnly"] = "debug-only";
     Option["Ascending"] = "ascending";
-    Option["SortIssuesBy"] = 'sort-issues-by';
+    Option["SortIssuesBy"] = "sort-issues-by";
     Option["DeleteBranch"] = "delete-branch";
     Option["StartDate"] = "start-date";
     Option["ExemptMilestones"] = "exempt-milestones";

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,5 @@
+const { sort } = require('semver');
+
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
@@ -684,6 +686,12 @@ class IssuesProcessor {
                     state: 'open',
                     per_page: 100,
                     direction: this.options.ascending ? 'asc' : 'desc',
+                    sort:
+                    this.options.sortIssuesBy === 'updated'
+                      ? 'updated'
+                      : this.options.sortIssuesBy === 'comments'
+                      ? 'comments'
+                      : 'created',
                     page
                 });
                 (_a = this.statistics) === null || _a === void 0 ? void 0 : _a.incrementFetchedItemsCount(issueResult.data.length);
@@ -2199,6 +2207,7 @@ var Option;
     Option["RemovePrStaleWhenUpdated"] = "remove-pr-stale-when-updated";
     Option["DebugOnly"] = "debug-only";
     Option["Ascending"] = "ascending";
+    Option["SortIssuesBy"] = 'sort-issues-by';
     Option["DeleteBranch"] = "delete-branch";
     Option["StartDate"] = "start-date";
     Option["ExemptMilestones"] = "exempt-milestones";
@@ -2542,6 +2551,7 @@ function _getAndValidateArgs() {
         removePrStaleWhenUpdated: _toOptionalBoolean('remove-pr-stale-when-updated'),
         debugOnly: core.getInput('debug-only') === 'true',
         ascending: core.getInput('ascending') === 'true',
+        sortIssuesBy: core.getInput('sort-issues-by'),
         deleteBranch: core.getInput('delete-branch') === 'true',
         startDate: core.getInput('start-date') !== ''
             ? core.getInput('start-date')

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -13,6 +13,7 @@ describe('Issue', (): void => {
   beforeEach((): void => {
     optionsInterface = {
       ascending: false,
+      sortIssuesBy:'created',
       closeIssueLabel: '',
       closeIssueMessage: '',
       closePrLabel: '',

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -571,6 +571,12 @@ export class IssuesProcessor {
         state: 'open',
         per_page: 100,
         direction: this.options.ascending ? 'asc' : 'desc',
+        sort:
+          this.options.sortIssuesBy === 'updated'
+            ? 'updated'
+            : this.options.sortIssuesBy === 'comments'
+            ? 'comments'
+            : 'created',
         page
       });
       this.statistics?.incrementFetchedItemsCount(issueResult.data.length);

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -26,6 +26,7 @@ export enum Option {
   RemovePrStaleWhenUpdated = 'remove-pr-stale-when-updated',
   DebugOnly = 'debug-only',
   Ascending = 'ascending',
+  SortIssuesBy = 'sort-issues-by',
   DeleteBranch = 'delete-branch',
   StartDate = 'start-date',
   ExemptMilestones = 'exempt-milestones',

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -30,6 +30,7 @@ export interface IIssuesProcessorOptions {
   removePrStaleWhenUpdated: boolean | undefined;
   debugOnly: boolean;
   ascending: boolean;
+  sortIssuesBy: string;
   deleteBranch: boolean;
   startDate: IsoOrRfcDateString | undefined; // Should be ISO 8601 or RFC 2822
   exemptMilestones: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,7 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ),
     debugOnly: core.getInput('debug-only') === 'true',
     ascending: core.getInput('ascending') === 'true',
+    sortIssuesBy: core.getInput('sort-issues-by'),
     deleteBranch: core.getInput('delete-branch') === 'true',
     startDate:
       core.getInput('start-date') !== ''


### PR DESCRIPTION
**Description:**
Introducing a new option `sort-issues-by` to sort the issues by the specified field. It accepts 'created', 'updated', 'comments' as values and default value is set to 'created', defines the sorting order of the issues in a repository.

**Related issue:**
Related to #1231 

**Check list:**
- [✓  ] Mark if documentation changes are required.
