### PR TITLE
Add Missing Input Reading for `only-issue-types`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2610,7 +2610,8 @@ function _getAndValidateArgs() {
         ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
         exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
         closeIssueReason: core.getInput('close-issue-reason'),
-        includeOnlyAssigned: core.getInput('include-only-assigned') === 'true'
+        includeOnlyAssigned: core.getInput('include-only-assigned') === 'true',
+        onlyIssueTypes: core.getInput('only-issue-types')
     };
     for (const numberInput of ['days-before-stale']) {
         if (isNaN(parseFloat(core.getInput(numberInput)))) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,7 +124,8 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
     exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
     closeIssueReason: core.getInput('close-issue-reason'),
-    includeOnlyAssigned: core.getInput('include-only-assigned') === 'true'
+    includeOnlyAssigned: core.getInput('include-only-assigned') === 'true',
+    onlyIssueTypes: core.getInput('only-issue-types')
   };
 
   for (const numberInput of ['days-before-stale']) {


### PR DESCRIPTION
**Description:**
Follow up for #1255. Turns out the added functionality was not working because the input was not read. This closed a number of issues for me which I had to repoen 😅 
I manually tested the changes proposed here (see https://github.com/python-telegram-bot/python-telegram-bot/pull/5005), so that should hopefully cover it.
Note that I did not add any new unit tests because I also did not find any tests that check this for the other inputs. Maybe a separate issue/PR could track that there is a centralized tests that ensures that all input is respected …
Looking forward to your feedback :)

**Related issue:**
PR: #1255
Re-closes #1187

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
