### PR TITLE
Improves error handling when rate limiting is disabled on GHES.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -750,15 +750,13 @@ class IssuesProcessor {
                 return new rate_limit_1.RateLimit(rateLimitResult.data.rate);
             }
             catch (error) {
-                if (error.status === 404 &&
-                    ((_a = error.message) === null || _a === void 0 ? void 0 : _a.includes('Rate limiting is not enabled'))) {
+                const status = error === null || error === void 0 ? void 0 : error.status;
+                const message = (_a = error === null || error === void 0 ? void 0 : error.message) !== null && _a !== void 0 ? _a : String(error);
+                if (status === 404 && message.includes('Rate limiting is not enabled')) {
                     logger.warning('Rate limiting is not enabled on this instance. Proceeding without rate limit checks.');
                     return undefined;
                 }
-                else {
-                    logger.error(`Error when getting rateLimit: ${error.message}`);
-                    return undefined;
-                }
+                logger.error(`Error when getting rateLimit: ${message}`);
             }
         });
     }

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -647,19 +647,18 @@ export class IssuesProcessor {
     try {
       const rateLimitResult = await this.client.rest.rateLimit.get();
       return new RateLimit(rateLimitResult.data.rate);
-    } catch (error: any) {
-      if (
-        error.status === 404 &&
-        error.message?.includes('Rate limiting is not enabled')
-      ) {
+    } catch (error: unknown) {
+      const status = (error as {status?: number})?.status;
+      const message = (error as {message?: string})?.message ?? String(error);
+
+      if (status === 404 && message.includes('Rate limiting is not enabled')) {
         logger.warning(
           'Rate limiting is not enabled on this instance. Proceeding without rate limit checks.'
         );
         return undefined;
-      } else {
-        logger.error(`Error when getting rateLimit: ${error.message}`);
-        return undefined;
       }
+
+      logger.error(`Error when getting rateLimit: ${message}`);
     }
   }
 


### PR DESCRIPTION
**Description:**
This pull request improves the error handling logic in the `getRateLimit` method of the `IssuesProcessor` class to better support environments where GitHub rate limiting is not enabled, such as some GitHub Enterprise Server (GHES) instances.

Error handling improvements for rate limiting:

* Updated the `catch` block in the `getRateLimit` method to specifically check for a 404 error with a message indicating that rate limiting is not enabled, logging a warning and proceeding gracefully without rate limit checks. For all other errors, an error is logged and the method returns `undefined` to ensure consistent fallback behavior.

**Related issue:**
https://github.com/actions/stale/issues/1227

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
