### PR TITLE
feat: add `ignore-labels-activity-updates-on-pr` option 

### DIFF
--- a/__tests__/classes/issues-processor-mock.ts
+++ b/__tests__/classes/issues-processor-mock.ts
@@ -1,6 +1,7 @@
 import {Issue} from '../../src/classes/issue';
 import {IssuesProcessor} from '../../src/classes/issues-processor';
 import {IComment} from '../../src/interfaces/comment';
+import {IIssueEvent} from '../../src/interfaces/issue-event';
 import {IIssuesProcessorOptions} from '../../src/interfaces/issues-processor-options';
 import {IPullRequest} from '../../src/interfaces/pull-request';
 import {IState} from '../../src/interfaces/state/state';
@@ -37,5 +38,10 @@ export class IssuesProcessorMock extends IssuesProcessor {
     if (getPullRequest) {
       this.getPullRequest = getPullRequest;
     }
+
+    // Mock _getIssueEvents to return empty array by default to avoid API calls in tests
+    (this as any)._getIssueEvents = async (): Promise<IIssueEvent[]> => {
+      return [];
+    };
   }
 }

--- a/__tests__/constants/default-processor-options.ts
+++ b/__tests__/constants/default-processor-options.ts
@@ -54,6 +54,7 @@ export const DefaultProcessorOptions: IIssuesProcessorOptions = Object.freeze({
   ignoreUpdates: false,
   ignoreIssueUpdates: undefined,
   ignorePrUpdates: undefined,
+  ignoreLabelsActivityUpdatesOnPr: '',
   exemptDraftPr: false,
   closeIssueReason: 'not_planned',
   includeOnlyAssigned: false

--- a/action.yml
+++ b/action.yml
@@ -204,6 +204,10 @@ inputs:
     description: 'Any update (update/comment) can reset the stale idle time on the pull requests. Override "ignore-updates" option regarding only the pull requests.'
     default: ''
     required: false
+  ignore-labels-activity-updates-on-pr:
+    description: 'Ignore activity from certain labels when determining if a PR has been updated. Useful for excluding bot labels from being considered as updates. Comma-separated list of labels.'
+    default: ''
+    required: false
   include-only-assigned:
     description: 'Only the issues or the pull requests with an assignee will be marked as stale automatically.'
     default: 'false'

--- a/src/classes/ignored-labels.spec.ts
+++ b/src/classes/ignored-labels.spec.ts
@@ -1,0 +1,284 @@
+import {DefaultProcessorOptions} from '../../__tests__/constants/default-processor-options';
+import {generateIIssue} from '../../__tests__/functions/generate-iissue';
+import {IIssue} from '../interfaces/issue';
+import {IIssueEvent} from '../interfaces/issue-event';
+import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
+import {IgnoredLabels} from './ignored-labels';
+import {Issue} from './issue';
+
+describe('IgnoredLabels', (): void => {
+  let ignoredLabels: IgnoredLabels;
+  let optionsInterface: IIssuesProcessorOptions;
+  let issue: Issue;
+  let issueInterface: IIssue;
+
+  beforeEach((): void => {
+    optionsInterface = {
+      ...DefaultProcessorOptions
+    };
+    issueInterface = generateIIssue();
+  });
+
+  describe('getIgnoredLabels()', (): void => {
+    describe('when the given issue is not a pull request', (): void => {
+      beforeEach((): void => {
+        issueInterface.pull_request = undefined;
+      });
+
+      it('should always return an empty array for issues', (): void => {
+        expect.assertions(1);
+        optionsInterface.ignoreLabelsActivityUpdatesOnPr =
+          'bot-label, automated';
+        issue = new Issue(optionsInterface, issueInterface);
+        ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+
+        const result = ignoredLabels.getIgnoredLabels();
+
+        expect(result).toStrictEqual([]);
+      });
+    });
+
+    describe('when the given issue is a pull request', (): void => {
+      beforeEach((): void => {
+        issueInterface.pull_request = {};
+      });
+
+      describe('when no ignore options are set', (): void => {
+        it('should return an empty array', (): void => {
+          expect.assertions(1);
+          issue = new Issue(optionsInterface, issueInterface);
+          ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+
+          const result = ignoredLabels.getIgnoredLabels();
+
+          expect(result).toStrictEqual([]);
+        });
+      });
+
+      describe('when ignoreLabelsActivityUpdatesOnPr is set', (): void => {
+        beforeEach((): void => {
+          optionsInterface.ignoreLabelsActivityUpdatesOnPr =
+            'pr-bot, merges-blocked';
+        });
+
+        it('should return the labels from ignoreLabelsActivityUpdatesOnPr', (): void => {
+          expect.assertions(1);
+          issue = new Issue(optionsInterface, issueInterface);
+          ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+
+          const result = ignoredLabels.getIgnoredLabels();
+
+          expect(result).toStrictEqual(['pr-bot', 'merges-blocked']);
+        });
+      });
+    });
+  });
+
+  describe('getEffectiveUpdateDate()', (): void => {
+    let events: IIssueEvent[];
+
+    beforeEach((): void => {
+      issueInterface.pull_request = {}; // Make it a PR so the logic applies
+      issueInterface.created_at = '2020-01-01T00:00:00Z';
+      issueInterface.updated_at = '2020-01-10T00:00:00Z';
+    });
+
+    describe('when no labels are ignored', (): void => {
+      beforeEach((): void => {
+        optionsInterface.ignoreLabelsActivityUpdatesOnPr = '';
+      });
+
+      it('should return the original updated_at date', (): void => {
+        expect.assertions(1);
+        issue = new Issue(optionsInterface, issueInterface);
+        ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+        events = [];
+
+        const result = ignoredLabels.getEffectiveUpdateDate(events);
+
+        expect(result).toBe('2020-01-10T00:00:00Z');
+      });
+    });
+
+    describe('when labels are ignored', (): void => {
+      beforeEach((): void => {
+        optionsInterface.ignoreLabelsActivityUpdatesOnPr =
+          'bot-label, merges-blocked';
+      });
+
+      describe('when there are no events', (): void => {
+        it('should return the original updated_at date', (): void => {
+          expect.assertions(1);
+          issue = new Issue(optionsInterface, issueInterface);
+          ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+          events = [];
+
+          const result = ignoredLabels.getEffectiveUpdateDate(events);
+
+          expect(result).toBe('2020-01-10T00:00:00Z');
+        });
+      });
+
+      describe('when all events are ignored label events', (): void => {
+        beforeEach((): void => {
+          events = [
+            {
+              event: 'labeled',
+              created_at: '2020-01-05T00:00:00Z',
+              label: {name: 'bot-label'}
+            },
+            {
+              event: 'labeled',
+              created_at: '2020-01-08T00:00:00Z',
+              label: {name: 'merges-blocked'}
+            }
+          ];
+        });
+
+        it('should return the creation date', (): void => {
+          expect.assertions(1);
+          issue = new Issue(optionsInterface, issueInterface);
+          ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+
+          const result = ignoredLabels.getEffectiveUpdateDate(events);
+
+          expect(result).toBe('2020-01-01T00:00:00Z');
+        });
+      });
+
+      describe('when there are mixed events', (): void => {
+        beforeEach((): void => {
+          events = [
+            {
+              event: 'commented',
+              created_at: '2020-01-03T00:00:00Z',
+              label: {name: ''}
+            },
+            {
+              event: 'labeled',
+              created_at: '2020-01-05T00:00:00Z',
+              label: {name: 'bot-label'}
+            },
+            {
+              event: 'labeled',
+              created_at: '2020-01-06T00:00:00Z',
+              label: {name: 'needs-review'}
+            },
+            {
+              event: 'labeled',
+              created_at: '2020-01-08T00:00:00Z',
+              label: {name: 'merges-blocked'}
+            }
+          ];
+        });
+
+        it('should return the most recent non-ignored event date', (): void => {
+          expect.assertions(1);
+          issue = new Issue(optionsInterface, issueInterface);
+          ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+
+          const result = ignoredLabels.getEffectiveUpdateDate(events);
+
+          // Most recent non-ignored event is 'needs-review' at 2020-01-06
+          expect(result).toBe('2020-01-06T00:00:00Z');
+        });
+      });
+
+      describe('when there are unlabeled events for ignored labels', (): void => {
+        beforeEach((): void => {
+          events = [
+            {
+              event: 'labeled',
+              created_at: '2020-01-03T00:00:00Z',
+              label: {name: 'needs-review'}
+            },
+            {
+              event: 'unlabeled',
+              created_at: '2020-01-05T00:00:00Z',
+              label: {name: 'bot-label'}
+            }
+          ];
+        });
+
+        it('should ignore unlabeled events for ignored labels', (): void => {
+          expect.assertions(1);
+          issue = new Issue(optionsInterface, issueInterface);
+          ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+
+          const result = ignoredLabels.getEffectiveUpdateDate(events);
+
+          // Most recent non-ignored event is 'needs-review' at 2020-01-03
+          expect(result).toBe('2020-01-03T00:00:00Z');
+        });
+      });
+
+      describe('when label names have different casing', (): void => {
+        beforeEach((): void => {
+          optionsInterface.ignoreLabelsActivityUpdatesOnPr =
+            'Bot-Label, MERGES-BLOCKED';
+          events = [
+            {
+              event: 'labeled',
+              created_at: '2020-01-03T00:00:00Z',
+              label: {name: 'needs-review'}
+            },
+            {
+              event: 'labeled',
+              created_at: '2020-01-05T00:00:00Z',
+              label: {name: 'bot-label'}
+            },
+            {
+              event: 'labeled',
+              created_at: '2020-01-08T00:00:00Z',
+              label: {name: 'Merges-Blocked'}
+            }
+          ];
+        });
+
+        it('should ignore labels case-insensitively', (): void => {
+          expect.assertions(1);
+          issue = new Issue(optionsInterface, issueInterface);
+          ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+
+          const result = ignoredLabels.getEffectiveUpdateDate(events);
+
+          // Most recent non-ignored event is 'needs-review' at 2020-01-03
+          expect(result).toBe('2020-01-03T00:00:00Z');
+        });
+      });
+
+      describe('when there are non-label events after ignored label events', (): void => {
+        beforeEach((): void => {
+          events = [
+            {
+              event: 'labeled',
+              created_at: '2020-01-05T00:00:00Z',
+              label: {name: 'bot-label'}
+            },
+            {
+              event: 'committed',
+              created_at: '2020-01-07T00:00:00Z',
+              label: {name: ''}
+            },
+            {
+              event: 'labeled',
+              created_at: '2020-01-08T00:00:00Z',
+              label: {name: 'merges-blocked'}
+            }
+          ];
+        });
+
+        it('should return the most recent non-label event', (): void => {
+          expect.assertions(1);
+          issue = new Issue(optionsInterface, issueInterface);
+          ignoredLabels = new IgnoredLabels(optionsInterface, issue);
+
+          const result = ignoredLabels.getEffectiveUpdateDate(events);
+
+          // Most recent non-ignored event is 'committed' at 2020-01-07
+          expect(result).toBe('2020-01-07T00:00:00Z');
+        });
+      });
+    });
+  });
+});

--- a/src/classes/ignored-labels.ts
+++ b/src/classes/ignored-labels.ts
@@ -1,0 +1,107 @@
+import {Option} from '../enums/option';
+import {wordsToList} from '../functions/words-to-list';
+import {IIssueEvent} from '../interfaces/issue-event';
+import {IIssuesProcessorOptions} from '../interfaces/issues-processor-options';
+import {Issue} from './issue';
+import {IssueLogger} from './loggers/issue-logger';
+
+/**
+ * @description
+ * This class is responsible for calculating the effective update time of an issue/PR
+ * by filtering out label events that should be ignored when determining if an issue has been updated.
+ * This is useful for excluding bot-added labels from being considered as human activity.
+ */
+export class IgnoredLabels {
+  private readonly _options: IIssuesProcessorOptions;
+  private readonly _issue: Issue;
+  private readonly _issueLogger: IssueLogger;
+
+  constructor(options: Readonly<IIssuesProcessorOptions>, issue: Issue) {
+    this._options = options;
+    this._issue = issue;
+    this._issueLogger = new IssueLogger(issue);
+  }
+
+  /**
+   * @description
+   * Get the list of labels that should be ignored when determining if a PR has been updated
+   *
+   * @returns {string[]} The list of label names to ignore (case-insensitive)
+   */
+  getIgnoredLabels(): string[] {
+    if (!this._issue.isPullRequest) {
+      return [];
+    }
+    return this._getIgnoredPrLabels();
+  }
+
+  /**
+   * @description
+   * Calculate the effective update time for the issue/PR by filtering out ignored label events.
+   * If there are events to filter, returns the most recent non-ignored event time.
+   * If all events are ignored, returns the creation date.
+   * If there are no ignored labels configured or no events, returns the original updated_at time.
+   *
+   * @param {IIssueEvent[]} events All events for the issue/PR
+   * @returns {string} The effective update timestamp
+   */
+  getEffectiveUpdateDate(events: IIssueEvent[]): string {
+    const ignoredLabels = this.getIgnoredLabels();
+
+    // If no labels to ignore, or no events found, return original updated_at
+    if (ignoredLabels.length === 0 || events.length === 0) {
+      return this._issue.updated_at;
+    }
+
+    // Filter events to find the most recent non-ignored event
+    // We look for events that are NOT labeled/unlabeled events with ignored labels
+    const nonIgnoredEvents = events.filter(event => {
+      // If it's not a label event, keep it
+      if (event.event !== 'labeled' && event.event !== 'unlabeled') {
+        return true;
+      }
+
+      // If it's a label event, check if the label is in the ignored list and filter it out
+      const isEventFromIgnoredLabel = ignoredLabels
+        .map(label => label.toLowerCase())
+        .includes(event.label?.name?.toLowerCase() || '');
+
+      return !isEventFromIgnoredLabel;
+    });
+
+    // If we have non-ignored events, return the most recent one
+    if (nonIgnoredEvents.length > 0) {
+      const mostRecentEvent = nonIgnoredEvents.reduce((latest, current) => {
+        return new Date(latest.created_at) > new Date(current.created_at)
+          ? latest
+          : current;
+      });
+
+      this._issueLogger.info(
+        `Most recent non-ignored activity: ${mostRecentEvent.event} at ${mostRecentEvent.created_at} (ignoring activity from labels: ${ignoredLabels})`
+      );
+      return mostRecentEvent.created_at;
+    }
+
+    // If all events are ignored label events, use the creation date
+    this._issueLogger.info(
+      `All recent activity is from ignored labels (${ignoredLabels}). Using creation date as effective update date: ${this._issue.created_at}`
+    );
+    return this._issue.created_at;
+  }
+
+  private _getIgnoredPrLabels(): string[] {
+    if (this._options.ignoreLabelsActivityUpdatesOnPr) {
+      this._issueLogger.info(
+        `The option ${this._issueLogger.createOptionLink(
+          Option.IgnoreLabelsActivityUpdatesOnPr
+        )} is set. Activity from these labels will be ignored when checking for updates: ${
+          this._options.ignoreLabelsActivityUpdatesOnPr
+        }`
+      );
+      return wordsToList(this._options.ignoreLabelsActivityUpdatesOnPr);
+    }
+
+    return [];
+  }
+}

--- a/src/classes/issue.spec.ts
+++ b/src/classes/issue.spec.ts
@@ -63,6 +63,7 @@ describe('Issue', (): void => {
       ignoreUpdates: false,
       ignoreIssueUpdates: undefined,
       ignorePrUpdates: undefined,
+      ignoreLabelsActivityUpdatesOnPr: '',
       exemptDraftPr: false,
       closeIssueReason: '',
       includeOnlyAssigned: false

--- a/src/enums/option.ts
+++ b/src/enums/option.ts
@@ -48,6 +48,7 @@ export enum Option {
   IgnoreUpdates = 'ignore-updates',
   IgnoreIssueUpdates = 'ignore-issue-updates',
   IgnorePrUpdates = 'ignore-pr-updates',
+  IgnoreLabelsActivityUpdatesOnPr = 'ignore-labels-activity-updates-on-pr',
   ExemptDraftPr = 'exempt-draft-pr',
   CloseIssueReason = 'close-issue-reason',
   OnlyIssueTypes = 'only-issue-types'

--- a/src/interfaces/issues-processor-options.ts
+++ b/src/interfaces/issues-processor-options.ts
@@ -52,6 +52,7 @@ export interface IIssuesProcessorOptions {
   ignoreUpdates: boolean;
   ignoreIssueUpdates: boolean | undefined;
   ignorePrUpdates: boolean | undefined;
+  ignoreLabelsActivityUpdatesOnPr: string;
   exemptDraftPr: boolean;
   closeIssueReason: string;
   includeOnlyAssigned: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,6 +122,9 @@ function _getAndValidateArgs(): IIssuesProcessorOptions {
     ignoreUpdates: core.getInput('ignore-updates') === 'true',
     ignoreIssueUpdates: _toOptionalBoolean('ignore-issue-updates'),
     ignorePrUpdates: _toOptionalBoolean('ignore-pr-updates'),
+    ignoreLabelsActivityUpdatesOnPr: core.getInput(
+      'ignore-labels-activity-updates-on-pr'
+    ),
     exemptDraftPr: core.getInput('exempt-draft-pr') === 'true',
     closeIssueReason: core.getInput('close-issue-reason'),
     includeOnlyAssigned: core.getInput('include-only-assigned') === 'true',


### PR DESCRIPTION
**Description:**

Adds a new option `ignore-labels-activity-updates-on-pr` to ignore label activity when determining if a PR has been updated.

**Problem:** When automated systems add labels (like `merge-conflict`, `ci-failed`, or `merges-blocked`), these label changes update the PR's `updated_at` timestamp, resetting the stale timer and preventing stale PRs from being closed even when there's no real human activity.

**Solution:** This PR adds filtering logic to exclude specified label events when calculating if a PR has been updated since being marked stale.

### Changes:
- Add `ignore-labels-activity-updates-on-pr` option to `action.yml`
- Create `IgnoredLabels` class to filter out ignored label events
- Refactor `issues-processor.ts` to fetch events once and calculate effective update date
- Add 10 comprehensive unit tests
- Update README with documentation and usage examples

### How it works:
1. Fetch all events for the PR
2. Filter out `labeled`/`unlabeled` events for specified labels
3. Calculate "effective update date" from most recent non-ignored activity
4. Use effective date when checking if PR should be closed

### Usage Example:
```yaml
- uses: actions/stale@v10
  with:
    days-before-stale: 30
    days-before-close: 7
    ignore-labels-activity-updates-on-pr: 'merge-conflict, ci-failed, merges-blocked'
```

### Testing:
- ✅ All 1,362 tests passing (29 test suites)
- ✅ 10 new unit tests for `IgnoredLabels` class
- ✅ `npm run all` passes (build, lint, pack, test)
- ✅ `dist/index.js` updated and committed

**Related issue:**
N/A - Feature request from internal use case

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.