### PR TITLE
don't account for bot comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ $ npm install
 Build the typescript and package it for distribution.
 
 ```bash
-$ npm run build && npm run pack
+$ npm run build
 ```
 
 Run the tests :heavy_check_mark:

--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -1247,6 +1247,44 @@ test('stale label should be removed if a comment was added to a stale issue', as
   expect(processor.removedLabelIssues).toHaveLength(1);
 });
 
+test('stale label should not be removed if a bot comment was added to a stale issue', async () => {
+  const opts = {...DefaultProcessorOptions, removeStaleWhenUpdated: true};
+  const TestIssueList: Issue[] = [
+    generateIssue(
+      opts,
+      1,
+      'An issue that should un-stale',
+      '2020-01-01T17:00:00Z',
+      '2020-01-01T17:00:00Z',
+      false,
+      false,
+      ['Stale']
+    )
+  ];
+  const processor = new IssuesProcessorMock(
+    opts,
+    alwaysFalseStateMock,
+    async p => (p === 1 ? TestIssueList : []),
+    async () => [
+      {
+        user: {
+          login: 'notme',
+          type: 'Bot'
+        },
+        body: 'Body'
+      }
+    ], // return a fake comment to indicate there was an update
+    async () => new Date().toDateString()
+  );
+
+  // process our fake issue list
+  await processor.processIssues(1);
+
+  expect(processor.closedIssues).toHaveLength(1);
+  expect(processor.staleIssues).toHaveLength(0);
+  expect(processor.removedLabelIssues).toHaveLength(0);
+});
+
 test('when the option "labelsToAddWhenUnstale" is set, the labels should be added when unstale', async () => {
   expect.assertions(4);
   const opts = {
@@ -1360,7 +1398,7 @@ test('stale label should not be removed if a comment was added by the bot (and t
       {
         user: {
           login: 'abot',
-          type: 'User'
+          type: 'Bot'
         },
         body: 'This issue is stale'
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -851,7 +851,7 @@ class IssuesProcessor {
             const comments = yield this.listIssueComments(issue, sinceDate);
             const filteredComments = comments.filter(comment => {
                 var _a, _b;
-                return ((_a = comment.user) === null || _a === void 0 ? void 0 : _a.type) === 'User' &&
+                return ((_a = comment.user) === null || _a === void 0 ? void 0 : _a.type) !== 'Bot' &&
                     ((_b = comment.body) === null || _b === void 0 ? void 0 : _b.toLowerCase()) !== staleMessage.toLowerCase();
             });
             issueLogger.info(`Comments that are not the stale comment or another bot: ${logger_service_1.LoggerService.cyan(filteredComments.length)}`);

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -840,7 +840,7 @@ export class IssuesProcessor {
 
     const filteredComments = comments.filter(
       comment =>
-        comment.user?.type === 'User' &&
+        comment.user?.type !== 'Bot' &&
         comment.body?.toLowerCase() !== staleMessage.toLowerCase()
     );
 


### PR DESCRIPTION
**Description:**
I was noticing that several of the places where I had instrumented the stale action it seemed like some of the pr's were having the label's appropriately applied but the action was never coming back around and closing them after the determined stale period.

I ran a small version of [this](https://github.com/actions/stale/blob/main/src/classes/issues-processor.ts#L551) as part of a small script and saw that the output indicated that the github actions comment was a 'Bot' type.

I had previously created this change set here, https://github.com/actions/stale/pull/1177 but given all the changes i thought to just start a new.

**Related issue:**
Add link to the related issue.

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
