### PR TITLE
Fix: Increase tolerance in isDateMoreRecentThan to 30s

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -803,9 +803,9 @@ class IssuesProcessor {
                 issueLogger.info(`marked stale this run, so don't check for updates`);
                 yield this._removeLabelsOnStatusTransition(issue, labelsToRemoveWhenStale, option_1.Option.LabelsToRemoveWhenStale);
             }
-            // The issue.updated_at and markedStaleOn are not always exactly in sync (they can be off by a second or 2)
-            // isDateMoreRecentThan makes sure they are not the same date within a certain tolerance (15 seconds in this case)
-            const issueHasUpdateSinceStale = (0, is_date_more_recent_than_1.isDateMoreRecentThan)(new Date(issue.updated_at), new Date(markedStaleOn), 15);
+            // The issue.updated_at and markedStaleOn are not always exactly in sync (they can be off by several seconds)
+            // isDateMoreRecentThan makes sure they are not the same date within a certain tolerance (30 seconds in this case)
+            const issueHasUpdateSinceStale = (0, is_date_more_recent_than_1.isDateMoreRecentThan)(new Date(issue.updated_at), new Date(markedStaleOn), 30);
             issueLogger.info(`$$type has been updated since it was marked stale: ${logger_service_1.LoggerService.cyan(issueHasUpdateSinceStale)}`);
             // Should we un-stale this issue?
             if (shouldRemoveStaleWhenUpdated &&

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -742,12 +742,12 @@ export class IssuesProcessor {
       );
     }
 
-    // The issue.updated_at and markedStaleOn are not always exactly in sync (they can be off by a second or 2)
-    // isDateMoreRecentThan makes sure they are not the same date within a certain tolerance (15 seconds in this case)
+    // The issue.updated_at and markedStaleOn are not always exactly in sync (they can be off by several seconds)
+    // isDateMoreRecentThan makes sure they are not the same date within a certain tolerance (30 seconds in this case)
     const issueHasUpdateSinceStale = isDateMoreRecentThan(
       new Date(issue.updated_at),
       new Date(markedStaleOn),
-      15
+      30
     );
 
     issueLogger.info(


### PR DESCRIPTION
**Description:**

This increases the "tolerance" of checking `updated_at` vs. `markedStaleOn` from 15 to 30 seconds. See linked thread but for us recently stalebot has been marking issues stale and then un-marking them because of its own actions, seemingly just because the timestamps are > 15s:

> ```
>   [#11353] Found this pull request last updated at: 2025-12-23T03:32:45Z
>   ...
>   [#11353] Pull request marked stale on: 2025-12-23T03:32:17Z
>   [#11353] Checking for comments on pull request since: 2025-12-23T03:32:17Z
>   ...
>   [#11353] Pull request has been updated since it was marked stale: true
>   [#11353] Pull request has been commented on: false
>   [#11353] Remove the stale label since the pull request has been updated and the workflow should remove the stale label when updated
> ```

Of course I do not know exactly what the ideal tolerance would be but 30 seconds seems relatively as "safe" as 15. Nor do I know the underlying reason the tolerance is no longer sufficient, perhaps there has been drift in the GH API over time. 

Of course alternatively this could be made configurable, but Im not sure how widespread this really is to warrant that.

**Related issue:**
See #1184 (it would close this in my case but Im not 100% certain if OP there has the same exact cause).

**See also:**
#816

**Check list:**
- [ ] ~~Mark if documentation changes are required.~~
- [ ] ~~Mark if tests were added or updated to cover the changes.~~
