### PR TITLE
feat: use pulls API when issue processing is fully disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ permissions:
   pull-requests: write
 ```
 
+**Pull requests only (no issue processing):**  
+When both [days-before-issue-stale](#days-before-issue-stale) and [days-before-issue-close](#days-before-issue-close) are set to `-1`, the action uses the pull requests API exclusively and does not require any `issues` permission:
+
+```yaml
+permissions:
+  pull-requests: write
+```
+
 You can find more information about the required permissions under the corresponding options that you wish to use.
 
 ## Statefulness
@@ -163,6 +171,8 @@ Default value: `60`
 
 Useful to override [days-before-stale](#days-before-stale) but only for the idle number of days before marking the issues as stale.
 
+If set to `-1` together with [days-before-issue-close](#days-before-issue-close) set to `-1`, the action will use the pull requests API exclusively to fetch items, avoiding the need for any `issues` permission in the workflow.
+
 Default value: unset
 
 #### days-before-pr-stale
@@ -189,6 +199,8 @@ Default value: `7`
 #### days-before-issue-close
 
 Override [days-before-close](#days-before-close) but only for the idle number of days before closing the stale issues.
+
+If set to `-1` together with [days-before-issue-stale](#days-before-issue-stale) set to `-1`, the action will use the pull requests API exclusively to fetch items, avoiding the need for any `issues` permission in the workflow.
 
 Default value: unset
 

--- a/__tests__/get-issues-api-selection.spec.ts
+++ b/__tests__/get-issues-api-selection.spec.ts
@@ -1,0 +1,191 @@
+import {IssuesProcessor} from '../src/classes/issues-processor';
+import {IIssuesProcessorOptions} from '../src/interfaces/issues-processor-options';
+import {DefaultProcessorOptions} from './constants/default-processor-options';
+import {alwaysFalseStateMock} from './classes/state-mock';
+
+jest.mock('@actions/github', () => ({
+  context: {
+    repo: {owner: 'test-owner', repo: 'test-repo'}
+  },
+  getOctokit: jest.fn(() => ({
+    rest: {
+      issues: {
+        listForRepo: jest.fn().mockResolvedValue({data: []}),
+        listComments: jest.fn().mockResolvedValue({data: []}),
+        listEvents: {
+          endpoint: {merge: jest.fn().mockReturnValue({})}
+        },
+        addLabels: jest.fn().mockResolvedValue({}),
+        removeLabel: jest.fn().mockResolvedValue({}),
+        createComment: jest.fn().mockResolvedValue({}),
+        update: jest.fn().mockResolvedValue({})
+      },
+      pulls: {
+        list: jest.fn().mockResolvedValue({data: []}),
+        get: jest.fn().mockResolvedValue({data: {}})
+      }
+    },
+    paginate: jest.fn().mockResolvedValue([])
+  }))
+}));
+
+function buildProcessor(opts: IIssuesProcessorOptions): {
+  processor: IssuesProcessor;
+  mockListForRepo: jest.Mock;
+  mockPullsList: jest.Mock;
+} {
+  const processor = new IssuesProcessor(opts, alwaysFalseStateMock);
+
+  const mockListForRepo = jest.fn().mockResolvedValue({data: []});
+  const mockPullsList = jest.fn().mockResolvedValue({data: []});
+
+  (processor as any).client = {
+    rest: {
+      issues: {listForRepo: mockListForRepo},
+      pulls: {list: mockPullsList}
+    }
+  };
+
+  return {processor, mockListForRepo, mockPullsList};
+}
+
+describe('getIssues API selection based on issue days configuration', () => {
+  test('uses issues.listForRepo when issue processing is enabled', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      daysBeforeIssueStale: 14,
+      daysBeforeIssueClose: 7
+    };
+    const {processor, mockListForRepo, mockPullsList} = buildProcessor(opts);
+
+    await processor.getIssues(1);
+
+    expect(mockListForRepo).toHaveBeenCalledTimes(1);
+    expect(mockPullsList).not.toHaveBeenCalled();
+  });
+
+  test('uses pulls.list when days-before-issue-stale and days-before-issue-close are both -1', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      daysBeforeIssueStale: -1,
+      daysBeforeIssueClose: -1
+    };
+    const {processor, mockListForRepo, mockPullsList} = buildProcessor(opts);
+
+    await processor.getIssues(1);
+
+    expect(mockPullsList).toHaveBeenCalledTimes(1);
+    expect(mockListForRepo).not.toHaveBeenCalled();
+  });
+
+  test('uses issues.listForRepo when only days-before-issue-stale is -1 but close is not', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      daysBeforeIssueStale: -1,
+      daysBeforeIssueClose: 7
+    };
+    const {processor, mockListForRepo, mockPullsList} = buildProcessor(opts);
+
+    await processor.getIssues(1);
+
+    expect(mockListForRepo).toHaveBeenCalledTimes(1);
+    expect(mockPullsList).not.toHaveBeenCalled();
+  });
+
+  test('uses issues.listForRepo when only days-before-issue-close is -1 but stale is not', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      daysBeforeIssueStale: 14,
+      daysBeforeIssueClose: -1
+    };
+    const {processor, mockListForRepo, mockPullsList} = buildProcessor(opts);
+
+    await processor.getIssues(1);
+
+    expect(mockListForRepo).toHaveBeenCalledTimes(1);
+    expect(mockPullsList).not.toHaveBeenCalled();
+  });
+
+  test('uses issues.listForRepo when days are NaN (falls back to daysBeforeStale)', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      daysBeforeStale: 14,
+      daysBeforeClose: 7,
+      daysBeforeIssueStale: NaN,
+      daysBeforeIssueClose: NaN
+    };
+    const {processor, mockListForRepo, mockPullsList} = buildProcessor(opts);
+
+    await processor.getIssues(1);
+
+    expect(mockListForRepo).toHaveBeenCalledTimes(1);
+    expect(mockPullsList).not.toHaveBeenCalled();
+  });
+
+  test('items returned via pulls.list are treated as pull requests', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      daysBeforeIssueStale: -1,
+      daysBeforeIssueClose: -1
+    };
+    const processor = new IssuesProcessor(opts, alwaysFalseStateMock);
+
+    const fakePr = {
+      number: 42,
+      title: 'A pull request',
+      state: 'open',
+      locked: false,
+      draft: false,
+      labels: [],
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+      milestone: null,
+      assignees: []
+    };
+
+    (processor as any).client = {
+      rest: {
+        issues: {listForRepo: jest.fn()},
+        pulls: {list: jest.fn().mockResolvedValue({data: [fakePr]})}
+      }
+    };
+
+    const issues = await processor.getIssues(1);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].isPullRequest).toBe(true);
+    expect(issues[0].number).toBe(42);
+  });
+
+  test('uses created sort for pulls.list when sortBy is comments (unsupported by pulls API)', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      daysBeforeIssueStale: -1,
+      daysBeforeIssueClose: -1,
+      sortBy: 'comments'
+    };
+    const {processor, mockPullsList} = buildProcessor(opts);
+
+    await processor.getIssues(1);
+
+    expect(mockPullsList).toHaveBeenCalledWith(
+      expect.objectContaining({sort: 'created'})
+    );
+  });
+
+  test('passes updated sort through to pulls.list when sortBy is updated', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      daysBeforeIssueStale: -1,
+      daysBeforeIssueClose: -1,
+      sortBy: 'updated'
+    };
+    const {processor, mockPullsList} = buildProcessor(opts);
+
+    await processor.getIssues(1);
+
+    expect(mockPullsList).toHaveBeenCalledWith(
+      expect.objectContaining({sort: 'updated'})
+    );
+  });
+});

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -581,8 +581,35 @@ export class IssuesProcessor {
 
   // grab issues from github in batches of 100
   async getIssues(page: number): Promise<Issue[]> {
+    const issuesDisabled =
+      this._getDaysBeforeIssueStale() < 0 &&
+      this._getDaysBeforeIssueClose() < 0;
+
     try {
       this.operations.consumeOperation();
+
+      if (issuesDisabled) {
+        const sortField = getSortField(this.options.sortBy);
+        const pullResult = await this.client.rest.pulls.list({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          state: 'open',
+          per_page: 100,
+          direction: this.options.ascending ? 'asc' : 'desc',
+          sort: sortField === 'comments' ? 'created' : sortField,
+          page
+        });
+        this.statistics?.incrementFetchedItemsCount(pullResult.data.length);
+
+        return pullResult.data.map(
+          (pr): Issue =>
+            new Issue(
+              this.options,
+              {...pr, pull_request: {}} as unknown as Readonly<OctokitIssue>
+            )
+        );
+      }
+
       const issueResult = await this.client.rest.issues.listForRepo({
         owner: context.repo.owner,
         repo: context.repo.repo,


### PR DESCRIPTION
## Description

When both `days-before-issue-stale` and `days-before-issue-close` are set to `-1`, `getIssues` now calls `pulls.list` instead of `issues.listForRepo`. This avoids the need for any `issues` permission in the workflow, since the GitHub issues API is never called.

Before this change, even with issue processing fully disabled via `-1`, the action would still call `issues.listForRepo` on every run — which requires `issues: read` or `issues: write`. This caused failures in setups where the GitHub App or token does not have issues permission (e.g. repositories with issues disabled, or App tokens scoped only to pull requests).

**Changes:**
- `src/classes/issues-processor.ts`: `getIssues` checks if issues are fully disabled (`daysBeforeIssueStale < 0 && daysBeforeIssueClose < 0`) and uses `pulls.list` in that case
- Sort field `comments` is mapped to `created` for the pulls API, which does not support comments sorting
- Items returned via `pulls.list` are mapped with `pull_request: {}` so they are correctly identified as pull requests downstream
- `__tests__/get-issues-api-selection.spec.ts`: 8 tests covering all branching conditions (both -1, only one -1, NaN fallback, PR mapping, sort field mapping)
- `README.md`: documents the permission optimization in the "Recommended permissions" section and in the `days-before-issue-stale` / `days-before-issue-close` option descriptions

## Related issue

Fixes https://github.com/actions/stale/issues/1307

## Check list

- [x] Documentation changes added (README updated with permission optimization notes)
- [x] Tests added to cover all branching conditions and PR mapping
