### PR TITLE
Skip processing of pull requests completely without log output when onlyIssueTypes is set.

### DIFF
--- a/__tests__/only-issue-types.spec.ts
+++ b/__tests__/only-issue-types.spec.ts
@@ -7,6 +7,10 @@ import {alwaysFalseStateMock} from './classes/state-mock';
 import * as core from '@actions/core';
 
 describe('only-issue-types option', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('should only process issues with allowed type', async () => {
     const opts: IIssuesProcessorOptions = {
       ...DefaultProcessorOptions,
@@ -148,10 +152,6 @@ describe('only-issue-types option', () => {
 
     // Case-insensitive regex handles variations and ANSI codes
     expect(allLogs).not.toMatch(/pull request/i);
-
-    infoSpy.mockRestore();
-    groupSpy.mockRestore();
-    warningSpy.mockRestore();
   });
 
   test('should process all issues and PRs if onlyIssueTypes is unset', async () => {

--- a/__tests__/only-issue-types.spec.ts
+++ b/__tests__/only-issue-types.spec.ts
@@ -77,9 +77,11 @@ describe('only-issue-types option', () => {
     ]);
   });
   test('should process allowed issue types and skip PRs without logs', async () => {
-    const infoSpy = jest.spyOn(core, 'info');
-    const groupSpy = jest.spyOn(core, 'group');
-    const warningSpy = jest.spyOn(core, 'warning');
+    const infoSpy = jest.spyOn(core, 'info').mockImplementation(() => {});
+    const groupSpy = jest
+      .spyOn(core, 'group')
+      .mockImplementation(async (_name, fn) => fn());
+    const warningSpy = jest.spyOn(core, 'warning').mockImplementation(() => {});
 
     const opts: IIssuesProcessorOptions = {
       ...DefaultProcessorOptions,

--- a/__tests__/only-issue-types.spec.ts
+++ b/__tests__/only-issue-types.spec.ts
@@ -4,6 +4,7 @@ import {IssuesProcessorMock} from './classes/issues-processor-mock';
 import {DefaultProcessorOptions} from './constants/default-processor-options';
 import {generateIssue} from './functions/generate-issue';
 import {alwaysFalseStateMock} from './classes/state-mock';
+import * as core from '@actions/core';
 
 describe('only-issue-types option', () => {
   test('should only process issues with allowed type', async () => {
@@ -71,8 +72,89 @@ describe('only-issue-types option', () => {
       'A question'
     ]);
   });
+  test('should process allowed issue types and skip PRs without logs', async () => {
+    const infoSpy = jest.spyOn(core, 'info');
+    const groupSpy = jest.spyOn(core, 'group');
+    const warningSpy = jest.spyOn(core, 'warning');
 
-  test('should process all issues if onlyIssueTypes is unset', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      onlyIssueTypes: 'bug'
+    };
+    const TestIssueList: Issue[] = [
+      generateIssue(
+        opts,
+        1,
+        'A bug issue',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        false,
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        'bug'
+      ),
+      generateIssue(
+        opts,
+        2,
+        'A feature issue',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        false,
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        'feature'
+      ),
+      generateIssue(
+        opts,
+        3,
+        'A pull request',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        true,
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        'feature'
+      )
+    ];
+    const processor = new IssuesProcessorMock(
+      opts,
+      alwaysFalseStateMock,
+      async p => (p === 1 ? TestIssueList : []),
+      async () => [],
+      async () => new Date().toDateString()
+    );
+    await processor.processIssues(1);
+
+    // Only the bug issue is processed
+    expect(processor.staleIssues.map(i => i.title)).toEqual(['A bug issue']);
+
+    // PR is silently skipped — no logs should mention it across all logging methods
+    const infoLogs = infoSpy.mock.calls.map(c => c[0]).join('\n');
+    const warningLogs = warningSpy.mock.calls.map(c => c[0]).join('\n');
+    const groupLogs = groupSpy.mock.calls.map(c => c[0]).join('\n');
+    const allLogs = [infoLogs, warningLogs, groupLogs].join('\n');
+
+    // Case-insensitive regex handles variations and ANSI codes
+    expect(allLogs).not.toMatch(/pull request/i);
+
+    infoSpy.mockRestore();
+    groupSpy.mockRestore();
+    warningSpy.mockRestore();
+  });
+
+  test('should process all issues and PRs if onlyIssueTypes is unset', async () => {
     const opts: IIssuesProcessorOptions = {
       ...DefaultProcessorOptions,
       onlyIssueTypes: ''
@@ -107,6 +189,21 @@ describe('only-issue-types option', () => {
         undefined,
         [],
         'feature'
+      ),
+      generateIssue(
+        opts,
+        3,
+        'A pull request',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        true,
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        'feature'
       )
     ];
     const processor = new IssuesProcessorMock(
@@ -119,7 +216,8 @@ describe('only-issue-types option', () => {
     await processor.processIssues(1);
     expect(processor.staleIssues.map(i => i.title)).toEqual([
       'A bug',
-      'A feature'
+      'A feature',
+      'A pull request'
     ]);
   });
 });

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -148,6 +148,10 @@ export class IssuesProcessor {
       if (!this.operations.hasRemainingOperations()) {
         break;
       }
+      // Skip PRs silently when onlyIssueTypes is set
+      if (this.options.onlyIssueTypes && issue.isPullRequest) {
+        continue;
+      }
 
       const issueLogger: IssueLogger = new IssueLogger(issue);
       if (this.state.isIssueProcessed(issue)) {


### PR DESCRIPTION
**Description:**
<p>
  This PR improves handling of the <code>onlyIssueTypes</code> option by silently skipping pull requests when the option is set, without generating log output.
</p>

<h3>Changes</h3>

<ul>
  <li>
    Updated <code>IssuesProcessor</code> logic to skip PRs silently when
    <code>onlyIssueTypes</code> is configured
  </li>
  <li>
    Added tests to verify:
    <ul>
      <li>only allowed issue types are processed</li>
      <li>PRs are skipped without log output</li>
      <li>issues and PRs are both processed when <code>onlyIssueTypes</code> is unset</li>
    </ul>
  </li>
  <li>
    Added <code>@actions/core</code> import in tests for logging spies
  </li>
</ul>

**Related issue:**
(https://github.com/actions/stale/issues/1331)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
