### PR TITLE
fix: `only-issue-types` does not affect PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,8 @@ A comma separated list of allowed issue types. Only issues with a matching type 
 
 If unset (or an empty string), this option will not alter the stale workflow.
 
+This option does not affect PRs.
+
 Default value: unset
 
 ### Usage

--- a/__tests__/only-issue-types.spec.ts
+++ b/__tests__/only-issue-types.spec.ts
@@ -122,4 +122,37 @@ describe('only-issue-types option', () => {
       'A feature'
     ]);
   });
+
+  test('should ignore onlyIssueTypes filter when item is a pull request', async () => {
+    const opts: IIssuesProcessorOptions = {
+      ...DefaultProcessorOptions,
+      onlyIssueTypes: 'bug'
+    };
+    const TestIssueList: Issue[] = [
+      generateIssue(
+        opts,
+        1,
+        'A pull request',
+        '2020-01-01T17:00:00Z',
+        '2020-01-01T17:00:00Z',
+        false,
+        true, // isPullRequest = true
+        [],
+        false,
+        false,
+        undefined,
+        [],
+        undefined // pull requests do not have an issue_type
+      )
+    ];
+    const processor = new IssuesProcessorMock(
+      opts,
+      alwaysFalseStateMock,
+      async p => (p === 1 ? TestIssueList : []),
+      async () => [],
+      async () => new Date().toDateString()
+    );
+    await processor.processIssues(1);
+    expect(processor.staleIssues.map(i => i.title)).toEqual(['A pull request']);
+  });
 });

--- a/src/classes/issues-processor.ts
+++ b/src/classes/issues-processor.ts
@@ -252,7 +252,7 @@ export class IssuesProcessor {
       return; // If the issue has an 'include-only-assigned' option set, process only issues with nonempty assignees list
     }
 
-    if (this.options.onlyIssueTypes) {
+    if (this.options.onlyIssueTypes && !issue.isPullRequest) {
       const allowedTypes = this.options.onlyIssueTypes
         .split(',')
         .map(t => t.trim().toLowerCase())


### PR DESCRIPTION
**Description:**
When the `only-issue-types` is set, this should only affect issues, not Pull Requests. 
However, since the GitHub API treats PRs and issues all as `issues`, this type checking was missing and all PRs were ignored if the `only-issue-types` was set.

**Related issue:**
- Closes #1331

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
